### PR TITLE
add notebook toxicity classification

### DIFF
--- a/.ci/index.json
+++ b/.ci/index.json
@@ -118,5 +118,13 @@
         "sub_category": "Linear Regression",
         "url": "https://raw.githubusercontent.com/GoogleCloudPlatform/ai-ml-recipes/main/notebooks/regression/linear_regression/penguim_weight_prediction.ipynb",
         "created_at": "10-15-2024"
+    },
+    {
+        "title": "Toxicity classification using Gemini fine-tuned",
+        "description": "Description: This notebook shows how to classify human text toxic comments into different Responsible AI harms categories: toxic, severe_toxic, obscene, threat, insult, identity_hate. It reads the Jigsaw Multilingual Toxic Comment Classification dataset, runs predictions using Gemini, fine-tunes the model and evaluates F1 scores and Precision scores for both models",
+        "category": "Generative AI",
+        "sub_category": "Classification",
+        "url": "https://raw.githubusercontent.com/GoogleCloudPlatform/ai-ml-recipes/main/notebooks/generative_ai/classification/toxicity_classification.ipynb",
+        "created_at": "12-11-2024"
     }
 ]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Please refer to each notebooks folder documentation for more information:
 
 **BigFrames (BigQuery Dataframes)**
 * Generative AI
-    * [Banner advertising understanding](./notebooks/generative_ai/content_generation/banner_advertising_understanding.ipynb)
+    * Content Generation
+        * [Banner advertising understanding](./notebooks/generative_ai/content_generation/banner_advertising_understanding.ipynb)
+    * Classification
+        * [Toxicity classification](./notebooks/generative_ai/classification/toxicity_classification.ipynb)
 * Regression
     * [Predict penguim weight](./notebooks/regression/linear_regression/penguim_weight_prediction.ipynb)
 

--- a/notebooks/generative_ai/classification/toxicity_classification.ipynb
+++ b/notebooks/generative_ai/classification/toxicity_classification.ipynb
@@ -1,0 +1,2428 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "ur8xi4C7S06n"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2024 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "JAPoU8Sm5E6e"
+   },
+   "source": [
+    "## Toxicity classification using Gemini fine-tuned\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "<table align=\"left\">\n",
+    "\n",
+    "<a href=\"https://github.com/GoogleCloudPlatform/ai-ml-recipes/blob/main/notebooks/generative_ai/classification/toxicity_classification.ipynb\">\n",
+    "<img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "View on GitHub\n",
+    "</a>\n",
+    "</td>\n",
+    "<td>\n",
+    "<a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/ai-ml-recipes/main/notebooks/generative_ai/classification/toxicity_classification.ipynb\">\n",
+    "<img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
+    "Open in Vertex AI Workbench\n",
+    "</a>\n",
+    "</td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "This notebook shows how to classify human text toxic comments into different Responsible AI harms categories: \"toxic\", \"severe_toxic\", \"obscene\", \"threat\", \"insult\", \"identity_hate\"\n",
+    "\n",
+    "#### **Steps**\n",
+    "Using Bigframes (BigQuery Dataframes),\n",
+    "1) It reads the [```Jigsaw Multilingual Toxic Comment Classification```](https://www.kaggle.com/competitions/jigsaw-multilingual-toxic-comment-classification/data) dataset \n",
+    "2) It preprocess the dataset and split into train and test for finetuning and metrics evaluation  \n",
+    "3) It requests the Gemini model API to classify the text comment for the different categories (multi-label classification)  \n",
+    "4) It evaluates the Precision scores and F1 scores\n",
+    "5) It fine-tunes the Gemini model for this type of classification and evaluates the results against the test dataset again to compare the quality increase"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "References:\n",
+    "- [BigQuery DataFrames](https://cloud.google.com/python/docs/reference/bigframes/latest)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aed92deeb4a0"
+   },
+   "source": [
+    "### Costs\n",
+    "\n",
+    "This tutorial uses billable components of Google Cloud:\n",
+    "\n",
+    "* BigQuery (compute)\n",
+    "* BigQuery ML\n",
+    "\n",
+    "Learn about [BigQuery compute pricing](https://cloud.google.com/bigquery/pricing#analysis_pricing_models)\n",
+    "and [BigQuery ML pricing](https://cloud.google.com/bigquery/pricing#bqml),\n",
+    "and use the [Pricing Calculator](https://cloud.google.com/products/calculator/)\n",
+    "to generate a cost estimate based on your projected usage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "i7EUnXsZhAGF"
+   },
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9O0Ka4W2MNF3",
+    "pycharm": {
+     "is_executing": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade google-cloud-bigquery google-cloud-aiplatform bigframes -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "oDfTjfACBvJk"
+   },
+   "source": [
+    "\n",
+    "1. [Select or create a Google Cloud project](https://console.cloud.google.com/cloud-resource-manager). When you first create an account, you get a $300 credit towards your compute/storage costs.\n",
+    "\n",
+    "2. [Make sure that billing is enabled for your project](https://cloud.google.com/billing/docs/how-to/modify-project).\n",
+    "\n",
+    "3. [Enable the BigQuery API](https://console.cloud.google.com/flows/enableapi?apiid=bigquery.googleapis.com).\n",
+    "\n",
+    "4. If you are running this notebook locally, install the [Cloud SDK](https://cloud.google.com/sdk)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "960505627ddf"
+   },
+   "source": [
+    "### Import dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from typing import List\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from google.cloud import bigquery, storage\n",
+    "\n",
+    "import bigframes.pandas as bpd\n",
+    "import bigframes.bigquery as bbq\n",
+    "from bigframes.dataframe import DataFrame\n",
+    "from bigframes.ml.model_selection import train_test_split\n",
+    "from bigframes.ml import metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
+   "source": [
+    "### Set BigQuery DataFrames options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"<YOUR_PROJECT_ID>\"\n",
+    "REGION = \"US\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before running, [create a BigQuery dataset](https://cloud.google.com/bigquery/docs/datasets) and a [BigQuery connection](https://cloud.google.com/bigquery/docs/create-cloud-resource-connection) and refer them below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "DATASET_ID = \"<YOUR_BQ_DATASET_NAME>\"\n",
+    "CONNECTION_ID = \"<YOUR_BQ_CONNECTION_ID>\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "bpd.options.bigquery.project = PROJECT_ID\n",
+    "bpd.options.bigquery.location = REGION\n",
+    "bpd.options.display.progress_bar = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9EMAqR37AfLS"
+   },
+   "source": [
+    "## Read the dataset using BigQuery Dataframes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EDAaIwHpQCDZ",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "df = bpd.read_csv(\"gs://dataproc-metastore-public-binaries/jigsaw/jigsaw-toxic-comment-train.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "classification_columns = [\"toxic\", \"severe_toxic\", \"obscene\", \"threat\", \"insult\", \"identity_hate\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize basic statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "_gPD0Zn1Stdb",
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>comment_text</th>\n",
+       "      <th>toxic</th>\n",
+       "      <th>severe_toxic</th>\n",
+       "      <th>obscene</th>\n",
+       "      <th>threat</th>\n",
+       "      <th>insult</th>\n",
+       "      <th>identity_hate</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0000997932d777bf</td>\n",
+       "      <td>Explanation\n",
+       "Why the edits made under my userna...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>000103f0d9cfb60f</td>\n",
+       "      <td>D'aww! He matches this background colour I'm s...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>000113f07ec002fd</td>\n",
+       "      <td>Hey man, I'm really not trying to edit war. It...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0001b41b1c6bb37e</td>\n",
+       "      <td>\"\n",
+       "More\n",
+       "I can't make any real suggestions on im...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0001d958c54c6e35</td>\n",
+       "      <td>You, sir, are my hero. Any chance you remember...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>00025465d4725e87</td>\n",
+       "      <td>\"\n",
+       "\n",
+       "Congratulations from me as well, use the to...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0002bcb3da6cb337</td>\n",
+       "      <td>COCKSUCKER BEFORE YOU PISS AROUND ON MY WORK</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>00031b1e95af7921</td>\n",
+       "      <td>Your vandalism to the Matt Shirvington article...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>00037261f536c51d</td>\n",
+       "      <td>Sorry if the word 'nonsense' was offensive to ...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>00040093b2687caa</td>\n",
+       "      <td>alignment on this subject and which are contra...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>10 rows × 8 columns</p>\n",
+       "</div>[10 rows x 8 columns in total]"
+      ],
+      "text/plain": [
+       "                 id                                       comment_text  toxic  \\\n",
+       "0  0000997932d777bf  Explanation\n",
+       "Why the edits made under my userna...      0   \n",
+       "1  000103f0d9cfb60f  D'aww! He matches this background colour I'm s...      0   \n",
+       "2  000113f07ec002fd  Hey man, I'm really not trying to edit war. It...      0   \n",
+       "3  0001b41b1c6bb37e  \"\n",
+       "More\n",
+       "I can't make any real suggestions on im...      0   \n",
+       "4  0001d958c54c6e35  You, sir, are my hero. Any chance you remember...      0   \n",
+       "5  00025465d4725e87  \"\n",
+       "\n",
+       "Congratulations from me as well, use the to...      0   \n",
+       "6  0002bcb3da6cb337       COCKSUCKER BEFORE YOU PISS AROUND ON MY WORK      1   \n",
+       "7  00031b1e95af7921  Your vandalism to the Matt Shirvington article...      0   \n",
+       "8  00037261f536c51d  Sorry if the word 'nonsense' was offensive to ...      0   \n",
+       "9  00040093b2687caa  alignment on this subject and which are contra...      0   \n",
+       "\n",
+       "   severe_toxic  obscene  threat  insult  identity_hate  \n",
+       "0             0        0       0       0              0  \n",
+       "1             0        0       0       0              0  \n",
+       "2             0        0       0       0              0  \n",
+       "3             0        0       0       0              0  \n",
+       "4             0        0       0       0              0  \n",
+       "5             0        0       0       0              0  \n",
+       "6             1        1       0       1              0  \n",
+       "7             0        0       0       0              0  \n",
+       "8             0        0       0       0              0  \n",
+       "9             0        0       0       0              0  \n",
+       "\n",
+       "[10 rows x 8 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total: 223549\n"
+     ]
+    }
+   ],
+   "source": [
+    "ids_count = df[\"id\"].count()\n",
+    "print(f\"Total: {ids_count}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "classification_counts = df[classification_columns].sum()\n",
+    "classification_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def plot_percentages(classification_counts: DataFrame, total: int):\n",
+    "    \n",
+    "    percentages = (classification_counts / total) * 100\n",
+    "\n",
+    "    plt.figure(figsize=(10, 5))\n",
+    "    plt.bar(percentages.index, percentages.values)\n",
+    "    plt.title('Distribution of Classifications (Percentage)')\n",
+    "    plt.xlabel('Classification Type')\n",
+    "    plt.ylabel('Percentage of Occurrences')\n",
+    "    plt.xticks(rotation=45)\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1MAAAIiCAYAAAAtsZJMAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACPWklEQVR4nOzdeXhM5///8ddMFiQRETRqbS1J1F47Re310VprqaWUWmsp3YKi9qWWqrWotdROKbWvVUtR+74HFSQiiZBI5vz+8Mt8pRHLCDOR5+O6eumcc+bMe+acOZPXue9zH5NhGIYAAAAAAM/EbO8CAAAAACA5IkwBAAAAgA0IUwAAAABgA8IUAAAAANiAMAUAAAAANiBMAQAAAIANCFMAAAAAYAPCFAAAAADYgDAFAAAAADYgTAFwCOPGjZOfn99Lea0WLVqoRYsW1se7d++Wn5+f1qxZ81JePyAgQJUrV34pr2WrO3fuqHfv3ipXrpz8/Pw0ePDgJFnv0qVL5efnp8uXLyfJ+p7V5cuX5efnp6VLl8abvm3bNtWpU0cFCxaUn5+fwsLC7Lad4vbH3bt3v/TXflr//vuvChYsqH379tm7lBTtzJkzeuutt3Tq1Cl7lwKkWM72LgDAq2fp0qXq2bOn9bGrq6vSpUsnPz8/VaxYUfXr15eHh8dzv05QUJAWLlyoqlWrKl++fM+9vqTkyLU9jZ9++knLli1Tp06dlD17duXOnfuxy8fGxmr58uVavny5Tp48qcjISL322msqVaqUmjZtqoIFC76kyp/drVu39Pnnnytv3rzq27evXF1dlSZNmhf+unPnzlWaNGlUv379F/5aSW3ChAkqXLiwihUrZp0WEBCgZcuWWR+7u7srW7Zsqlu3rpo3by5XV1d7lJpktm7dqkOHDqlLly72LsUqT548qlixon788UeNHz/e3uUAKRJhCsAL07VrV2XLlk0xMTG6efOm9uzZoyFDhmjmzJmaOHGi/P39rct27NhR7dq1e6b1X79+XePHj1fWrFmfKbD8/PPPz/Q6tnhcbQMHDpRhGC+8huexa9cuFS5cWJ07d37isvfu3VPnzp21fft2lShRQu3bt1e6dOl05coV/fHHH1q2bJm2bNmizJkzv4TKHy9r1qw6dOiQnJ3/7+fv8OHDunPnjrp166ayZctap7/o7fTrr78qffr0CcJUiRIldOjQIbm4uLyw134eISEhWr58uYYNG5ZgnqurqwYNGiRJCg8P19q1azV8+HAdPnxYY8aMedmlJqmtW7dq7ty5DhWmJKlJkyZq166dLl26pBw5cti7HCDFIUwBeGEqVKgQr0Wiffv22rlzpzp06KBOnTpp9erVSp06tSTJ2dk53h+4L8Ldu3eVJk0au58hd9Q/kh8WHBysPHnyPNWyI0aM0Pbt29WzZ0+1atUq3rzOnTtr5syZSV+gjUwmk1KlShVvWkhIiCQpbdq08abbazuZzeYENTqSFStWyMnJSZUqVUowz9nZWXXq1LE+btq0qRo2bKjVq1crICBAPj4+Nr+uxWLR/fv3HfqzsYeyZcsqXbp0WrZsmbp162bvcoAUh2umALxUZcqUUadOnXTlyhWtWLHCOv1R10zt2LFDH330kYoXL66iRYuqRo0aGj16tKQH15V8+OGHkqSePXvKz88v3rUwLVq00Pvvv68jR46oWbNmKly4sPW5/71mKo7FYtHo0aNVrlw5FSlSRB06dNC///4bb5nKlSsrICAgwXMfXueTanvUtTiRkZEaNmyYKlasqAIFCqhGjRr6+eefE7SM+Pn5acCAAdqwYYPef/99FShQQLVq1dK2bdse97FbBQcHq1evXipbtqwKFiyo2rVrx+uaFXe9zuXLl7VlyxZr7Yld43Tt2jUtWLBA5cqVSxCkJMnJyUlt2rR5bKvUhg0b1K5dO73zzjsqUKCAqlatqgkTJig2NjbechcuXFCXLl1Urlw5FSxYUBUqVFD37t0VHh5uXeZx+4yU8JqpFi1a6JtvvpEkffjhh/Lz87Nu30dtJ4vFolmzZumDDz5QwYIFVbp0abVp00aHDx+2LrNkyRJ9/PHHKlOmjAoUKKD//e9/mjdvXrz1VK5cWadPn9aePXusn/HD+8+jrpn6448/VL9+fRUqVEilSpXSl19+qaCgoHjLBAQEqGjRogoKClKnTp1UtGhRlS5dWsOHD0/wea5atUr169dX0aJF9fbbb+uDDz7QrFmzEt1OcTZs2KBChQrJ3d39icuazWaVLFlSknTlyhVJUnR0tH788UdVq1ZNBQoUUMWKFTVixAhFR0fHe27cvr5ixQrVqlVLBQsW1Pbt2yU96Ebbq1cv6z5TuXJl9evXL946wsLCNHjwYOt3qlq1apoyZYosFot1mbj94eeff9aCBQtUtWpVFShQQA0aNNChQ4fifa5z58611hX3X5yff/5ZTZo0UalSpVSoUCHVr1//kddg3rt3T4MGDVKpUqVUtGhRdejQQUFBQfLz89O4cePiLRsUFKSePXuqbNmy1u/54sWLE6zTxcVFJUuW1MaNG5+4PQAkPVqmALx0derU0ejRo/Xnn3+qUaNGj1zm9OnTat++vfz8/NS1a1e5urrq4sWL2r9/vyQpd+7c6tq1q3788Uc1btzYeu3G22+/bV1HaGio2rZtq1q1aql27drKkCHDY+uaNGmSTCaT2rZtq+DgYM2aNUutWrXSb7/9Zm1BexpPU9vDDMNQx44drSEsX7582r59u0aMGGH9o/Fh+/bt07p169S0aVO5u7trzpw56tq1qzZv3qz06dMnWte9e/fUokULXbp0Sc2aNVO2bNm0Zs0aBQQEKCwsTC1btlTu3Lk1YsQIDR06VJkzZ9Ynn3wiSfL29n7kOrdt26aYmBjVrl37qT+f/1q2bJnc3Nz0ySefyM3NTbt27dKPP/6oiIgIa9CJjo5WmzZtFB0drebNmytjxowKCgrSli1bFBYWprRp0z5xn3mUDh066M0339SCBQus3VIf11Wqd+/eWrp0qSpUqKAPP/xQsbGx2rt3rw4ePGhthf3111+VN29eVa5cWc7Oztq8ebP69+8vwzDUrFkzSVKvXr00cOBAubm5qUOHDpKkjBkzJvq6cdchFixYUD169FBwcLBmz56t/fv3a/ny5fL09LQuGxsbqzZt2qhQoUL6+uuvtXPnTk2fPl3Zs2dX06ZNJT0InT169FCZMmX05ZdfSpLOnTun/fv3q2XLlonWcf/+fR0+fFgfffRRosv8V2BgoCTJy8tLFotFHTt21L59+9SoUSPlzp1bp06d0qxZs3ThwgVNnDgx3nN37dqlP/74Q82aNVP69OmVNWtWBQUF6cMPP1R4eLgaNWqkXLlyKSgoSGvXrtW9e/fk6uqqu3fvqnnz5goKClKTJk30+uuv659//tHo0aN148YN9e7dO97r/P7777pz544aN24sk8mkadOmqUuXLtqwYYNcXFzUuHFjXb9+XTt27NCIESMSvMfZs2ercuXK+uCDD3T//n2tWrVK3bp1008//aR3333XulxAQID++OMP1alTR4ULF9bff//9yO7NN2/eVKNGjWQymdSsWTN5e3tr27Zt6t27tyIiIhKcuMifP782btyoiIiIJLkeFcAzMAAgiS1ZssTw9fU1Dh06lOgyxYoVM+rWrWt9/OOPPxq+vr7WxzNmzDB8fX2N4ODgRNdx6NAhw9fX11iyZEmCec2bNzd8fX2NX3/99ZHzmjdvbn28a9cuw9fX1yhfvrwRHh5unb569WrD19fXmDVrlnVapUqVjG+++eaJ63xcbd98841RqVIl6+P169cbvr6+xsSJE+Mt16VLF8PPz8+4ePGidZqvr6+RP3/+eNOOHz9u+Pr6GnPmzEnwWg+bOXOm4evra/z222/WadHR0Ubjxo2NIkWKxHvvlSpVMtq1a/fY9RmGYQwZMsTw9fU1jh079sRlDeP/9o3AwEDrtLt37yZYrk+fPkbhwoWNqKgowzAM49ixY4avr6/xxx9/JLrup9lnAgMDE2yXxPbX/26nnTt3Gr6+vsbAgQMTrNdisTz2/bRu3dqoUqVKvGm1atWKt8/Eidsfd+3aZRjGg21UpkwZ4/333zfu3btnXW7z5s2Gr6+vMXbs2Hg1+/r6GuPHj4+3zrp16xr16tWzPh40aJDx9ttvGzExMQle/3EuXryY6L72zTffGEWKFDGCg4ON4OBg4+LFi8bkyZMNPz8/44MPPjAMwzCWL19u+Pv7G3///Xe85/7666+Gr6+vsW/fPus0X19fw9/f3zh9+nS8Zb/++mvD39//kceXuO0wYcIEo0iRIsb58+fjzR85cqSRL18+4+rVq4Zh/N/+ULJkSSM0NNS63IYNGwxfX19j06ZN1mn9+/ePd4x62H+3eXR0tPH+++8bH3/8sXXakSNHDF9fX2Pw4MHxlg0ICDB8fX2NH3/80TqtV69eRrly5YyQkJB4y3bv3t0oVqxYgtdbuXKl4evraxw8ePCR9QF4cejmB8Au3NzcdOfOnUTnx51p37hxY7xuOc/C1dX1mUZKq1u3bryzuu+9954yZcqkrVu32vT6T2vbtm1ycnJK0PWwdevWMgwjQRe+smXLxms98ff3l4eHh7UF4HGvkylTJr3//vvWaS4uLmrRooUiIyP1999/P3PtERERkvRUXb4S83CrX0REhEJCQlS8eHHdvXtX586dkyTrdvnzzz919+7dR64nKfaZx1m3bp1MJtMjB+UwmUzW/3/4/YSHhyskJEQlS5ZUYGBgvC6JT+vIkSMKDg7WRx99FO96oXfffVe5cuXSli1bEjznvy1HxYoVi9dV09PTU3fv3tWOHTueqZbQ0FDr8x8lMjJSZcqUUZkyZVStWjWNHj1aRYoU0YQJEyRJa9asUe7cuZUrVy6FhIRY/ytdurQkJejaWKJEiXjX7lksFm3YsEGVKlV65AiRcdthzZo1KlasmDw9PeO9TtmyZRUbG5tgX//f//6ndOnSWR8XL15ckp74nYrz8Da/ffu2wsPDVaxYMR07dsw6Pa6LYlzrYJzmzZvHe2wYhtatW6fKlSvLMIx49b/zzjsKDw/X0aNH4z0nbnvcunXrqeoFkHTo5gfALiIjIx/b7e5///ufFi1apG+//VajRo2y/nH23nvvyWx+uvNAPj4+zzTYRM6cOeM9NplMypkzp/VajxflypUreu211xJ0z4kbjvy/r//6668nWEe6dOkUFhb2xNfJmTNngs8v7nWuXr36zLXH1fy4YPwkp0+f1g8//KBdu3ZZw1mcuPCRPXt2ffLJJ5oxY4ZWrlyp4sWLq3Llyqpdu7Z14Iik2Gce59KlS3rttdfk5eX12OX27duncePG6cCBAwmCX3h4eIKBLp4kbru8+eabCeblypUrwb2eUqVKlaBbZrp06XT79m3r46ZNm+qPP/5Q27Zt5ePjo3LlyqlmzZqqUKHCU9VkJDLKYapUqTR58mRJD05mZMuWLd71chcvXtTZs2dVpkyZRz4/ODg43uNs2bLFexwSEqKIiAjlzZv3sfVdvHhRJ0+eTPR14gYdifPf71RcsHrSdyrO5s2bNWnSJB0/fjzedVsPh+yrV6/KbDYneE//Pe6EhIQoLCxMCxYs0IIFC56q/sS2B4AXjzAF4KW7du2awsPDH3ttSurUqTV37lzt3r1bW7Zs0fbt27V69WotWLBA06dPl5OT0xNf51muc3pesbGxT1VTUkjsdezxB1WuXLkkSSdPnrTpflphYWFq3ry5PDw81LVrV+XIkUOpUqXS0aNHNXLkyHgtTAEBAapXr542btyoHTt2aNCgQfrpp5+0cOFCZc6cOUn2med16dIltWrVSrly5VJAQIBef/11ubi4aOvWrZo5c+YLaTH7r6d5nxkyZNDy5cv1559/atu2bdq2bZuWLl2qunXravjw4Yk+Ly5IJhYynJyc4g0v/18Wi0W+vr7x7kP3sP8OVGLrd9hisahcuXL69NNPHzn/jTfeiPf4eb5Te/fuVceOHVWiRAn169dPmTJlkouLi5YsWaLff//dptolqXbt2qpXr94jl/nvYD1x2+Nx10wCeDEIUwBeut9++02S9M477zx2ObPZbO0y1LNnT02ePFljxozR7t27VbZs2XhnfZPCxYsX4z02DEMXL16M94dLYi1AV69eVfbs2a2Pn6W2rFmzaufOnQkuHo/r4pY1a9anXteTXufkyZOyWCzxWmriXidLlizPvM4KFSrIyclJK1euVN26dZ/5+Xv27FFoaKjGjx+vEiVKWKcnNnpg3ChqnTp10v79+/XRRx/p119/Vffu3SU9eZ95Hjly5NCff/6p0NDQRFunNm3apOjoaE2aNCne5/nf7mvS0+8jces5f/58gpaW8+fP27TdpActR5UrV1blypVlsVj03XffacGCBerUqVOC1pI4r7/+ulKnTp3o9nmSHDly6MSJEypTpoxN319vb295eHjo9OnTT3ydyMjI597mD0us3rVr1ypVqlT6+eef47WEL1myJN5yWbJkkcVi0eXLl+OFuf8ed7y9veXu7i6LxfLU9V++fFlms/mRrZcAXiyumQLwUu3cuVMTJ05UtmzZHjsCXNy1GQ+La/mI60aTJk0aSU/fFedJli9fHq+b2Zo1a3Tjxo14XZ+yZ8+ugwcPxuvKs3nz5gRDqD9LbRUqVFBsbKx16OU4M2fOlMlkeuquV0/zOjdu3NDq1aut02JiYjRnzhy5ubnFCzNP6/XXX1fDhg31559/as6cOQnmWywWTZ8+XdeuXXvk8+NC3cMtANHR0QmGEo+IiFBMTEy8ab6+vjKbzdZt8TT7zPOoXr26DMPQ+PHjE8yLqz+uhePh9xMeHp7gD2vpwT7yNPtHgQIFlCFDBs2fPz/e+9i6davOnj0bb7S4p/Xfa2vMZrP1pMHjPisXFxcVKFBAR44ceebXlKSaNWsqKChICxcuTDDv3r17ioyMfOzzzWazqlatqs2bN8cbjj5O3Odes2ZN/fPPP9brlB4WFhaWYF96Gol9p52cnGQymeINPX/58uUEQ5XHnTz67779yy+/JFhfjRo1tHbtWp06dSpBHf/t4idJR48eVZ48eZ65CymA50fLFIAXZtu2bTp37pxiY2N18+ZN7d69Wzt27FCWLFk0adKkx958c8KECdq7d68qVqyorFmzKjg4WPPmzVPmzJmtQ43nyJFDnp6emj9/vtzd3eXm5qZChQrFayF6FunSpVPTpk1Vv35969DoOXPmjDd8e8OGDbV27Vp9+umnqlmzpi5duqSVK1cm6LL4LLVVrlxZpUqV0pgxY3TlyhX5+flpx44d2rhxo1q2bPnY7pDPonHjxlqwYIECAgJ09OhRZc2aVWvXrtX+/fvVq1cvm4dUDggIUGBgoAYNGqR169apUqVK8vT01L///qs1a9bo3LlzqlWr1iOfW7RoUaVLl04BAQFq0aKFTCaTfvvttwTdq3bt2qUBAwbovffe0xtvvKHY2Fj99ttv1j88pafbZ55H6dKlVadOHc2ZM0cXL15U+fLlZbFYtG/fPpUqVUrNmzdXuXLl5OLiog4dOqhJkya6c+eOFi1apAwZMujGjRvx1pc/f379+uuvmjhxonLmzClvb+9HXuPj4uKiL7/8Uj179lTz5s1Vq1Yt69DoWbNmfeT9vZ7k22+/1e3bt1W6dGn5+Pjo6tWr+uWXX5QvXz7rNXSJqVKlisaMGWPTMNx16tTRH3/8oX79+mn37t16++23FRsbq3PnzmnNmjWaNm3aIweWeFiPHj20Y8cOtWjRwjq8+o0bN7RmzRrNmzdPnp6eatOmjTZt2qQOHTqoXr16yp8/v+7evatTp05p7dq12rhxY6LD/Scmf/78kqRBgwbpnXfekZOTk2rVqqWKFStqxowZ+vTTT/X+++9b97scOXLo5MmT1ufH3T9u1qxZCg0NtQ6NfuHCBUnxW76++OIL7d69W40aNVLDhg2VJ08e3b59W0ePHtXOnTu1Z88e67L379/X33///UzD1QNIOoQpAC/Mjz/+KOnBH4NeXl7y9fVVr169VL9+/Sf+EVa5cmVduXJFS5Ys0a1bt5Q+fXqVLFlSXbp0sZ59dXFx0bBhwzR69Gh99913iomJ0dChQ20OUx06dNDJkyc1ZcoU3blzR2XKlFG/fv2sZ6QlqXz58goICNCMGTM0ZMgQFShQQJMnT05wncmz1GY2mzVp0iT9+OOPWr16tZYuXaqsWbPq66+/VuvWrW16L4+SOnVqzZkzRyNHjtSyZcsUERGhN998U0OHDn2mUQ//K02aNJo6daqWLl2q5cuXa+LEibp3755ee+01lSpVSiNHjpSPj88jn5s+fXrr5/fDDz/I09NTtWvXVpkyZdSmTRvrcn5+fnrnnXe0efNmBQUFKU2aNPLz89PUqVNVpEgRSU+3zzyvoUOHys/PT4sXL9aIESOUNm1aFShQQEWLFpX04BqyH3/8UT/88IOGDx+ujBkz6qOPPpK3t3eC+4V99tlnunr1qqZNm6Y7d+6oZMmSiQ6YUL9+faVOnVpTp07VyJEj5ebmpqpVq+qrr75KdGS9x6ldu7YWLlyoefPmKSwsTJkyZVLNmjXVpUuXJw7WUadOHY0aNUobN25UnTp1nul1zWazJkyYoJkzZ+q3337T+vXrlSZNGmXLlk0tWrR4qm5qPj4+WrhwocaOHauVK1cqIiJCPj4+qlChgvUaqzRp0mjOnDn66aeftGbNGi1fvlweHh564403bN4fqlevrhYtWmjVqlVasWKFDMNQrVq1VKZMGQ0ePFhTp07VkCFDlC1bNn355Ze6cuVKvDAlybpPrFq1SuvXr1fZsmU1ZswYvffee/G6CGbMmFGLFi3ShAkTtH79ev3666/y8vJSnjx5rPcFi7Nz506FhoYmen0VgBfLZDAEDAAAeAa9evXShQsXEnRZw7M7fvy46tatq++//96mm1936tRJJpPJOvw8gJeLa6YAAMAz6dy5sw4fPpxgWHY83r179xJMmzVrlsxms03XLJ49e1ZbtmxRt27dkqI8ADagZQoAAOAlGD9+vI4cOaLSpUvLycnJOix948aNNWDAAHuXB8AGhCkAAICXYMeOHRo/frzOnj2ryMhIvf7666pTp446dOggZ2cuYweSI4cKUxcvXtTPP/+sgwcP6vTp08qVK9cjb3i3aNEiTZs2TVevXtWbb76p7t27q1KlSnaoGAAAAEBK5VDXTJ0+fVpbt25Vzpw5Ex2addWqVerTp49q1qxpHcWpc+fOOnDgwMstFgAAAECK5lAtUxaLxToka0BAgI4cOZKgZapGjRoqUKCARo0aZZ3WpEkTpU2bVlOnTn2p9QIAAABIuRyqZepJ97YIDAzUhQsXVLNmzXjT//e//2nnzp1Jcod7AAAAAHgayepqx3PnzklSgpv65c6dW/fv31dgYOAT79yeGMMwZLE4TCNdsmc2m/g8X3Fs45SB7fzqYxunDGznVx/bOOmYzSaZTKanWjZZhanbt29LUoK7vcc9jptvKycnh2qoS/acnJ5uJ0TyxTZOGdjOrz62ccrAdn71sY1fvmQVpl4ki8VQWFikvct4JTg5meXpmUZhYXcVG2uxdzl4AdjGKQPb+dXHNk4Z2M6vPrZx0vL0TPPUjSzJKkylS5dOkhQeHq5MmTJZp4eFhcWbb6uYGHa+pBQba+EzfcWxjVMGtvOrj22cMrCdX31s45cvWfVry5Url6T/u3Yqzrlz5+Ti4qLs2bPboywAAAAAKVCyClPZs2fXG2+8oTVr1sSbvnr1apUpU0aurq52qgwAAABASuNQ3fzu3r2rrVu3SpKuXLmiiIgIa3AqWbKkvL291aVLF3355ZfKkSOHSpUqpdWrV+vQoUP65Zdf7Fk6AAAAgBTGocJUcHCwunXrFm9a3OPZs2erVKlSev/993X37l1NnTpVU6ZM0Ztvvqnx48eraNGi9igZAAAAQArlUGEqW7ZsOnny5BOXa9iwoRo2bPgSKgIAAACAR0tW10wBAAAAgKMgTAEAAACADQhTAAAAAGADwhQAAAAA2IAwBQAAAAA2IEwBAAAAgA0IUwAAAABgA8IUAAAAANjAoW7aiwfMZpPMZpO9y7CZk5M53r/JkcViyGIx7F0GAAAAHBhhysGYzSZ5ebkl6yASx9Mzjb1LsFlsrEWhoZEEKgAAACSKMOVgzGaTnJzMGjl3ny4Hhdu7nBQpm09afdmsmMxmE2EKAAAAiSJMOajLQeE6e+W2vcsAAAAAkIjk35cMAAAAAOyAMAUAAAAANiBMAQAAAIANCFMAAAAAYAPCFAAAAADYgDAFAAAAADYgTAEAAACADQhTAAAAAGADwhQAAAAA2IAwBQAAAAA2IEwBAAAAgA0IUwAAAABgA8IUAAAAANiAMAUAAAAANiBMAQAAAIANCFMAAAAAYAPCFAAAAADYgDAFAAAAADYgTAEAAACADQhTAAAAAGADwhQAAAAA2IAwBQAAAAA2IEwBAAAAgA0IUwAAAABgA8IUAAAAANiAMAUAAAAANiBMAQAAAIANCFMAAAAAYAPCFAAAAADYgDAFAAAAADYgTAEAAACADQhTAAAAAGADwhQAAAAA2IAwBQAAAAA2IEwBAAAAgA0IUwAAAABgA8IUAAAAANiAMAUAAAAANiBMAQAAAIANCFMAAAAAYAPCFAAAAADYgDAFAAAAADYgTAEAAACADQhTAAAAAGADwhQAAAAA2IAwBQAAAAA2IEwBAAAAgA0IUwAAAABgA8IUAAAAANiAMAUAAAAANiBMAQAAAIANCFMAAAAAYINkGaY2btyohg0bqmjRonrnnXfUrVs3BQYG2rssAAAAAClIsgtTu3fvVufOnZUnTx5NmDBBvXr10okTJ9S6dWvdu3fP3uUBAAAASCGc7V3As1q1apWyZMmiIUOGyGQySZK8vb3VsmVLHTlyRMWLF7dzhQAAAABSgmTXMhUTEyN3d3drkJKktGnTSpIMw7BXWQAAAABSmGTXMlW/fn399ttvmjt3rmrXrq3Q0FCNHj1ab731lt5+++3nWrezs/2zpZOT/WvAA2yLxMV9NnxGrza286uPbZwysJ1ffWxj+zEZybA5Z/Pmzfriiy90584dSVK+fPk0bdo0ZcyY0eZ1GoYRr7XL3j4fvUVnr9y2dxkpUu6s6fRDj3ftXQYAAAAcXLJrmdq/f7++/vprNWrUSO+++65CQ0M1ceJEtWvXTvPmzVPq1KltWq/FYigsLDKJq312Tk5meXqmsXcZkBQWdlexsRZ7l+GQ4vZTPqNXG9v51cc2ThnYzq8+tnHS8vRM89StfMkuTA0aNEilS5dWQECAdVqRIkX07rvv6rffflPjxo1tXndMDDsf/k9srIV94gn4jFIGtvOrj22cMrCdX31s45cv2XWsPHv2rPz9/eNNy5w5s9KnT69Lly7ZqSoAAAAAKU2yC1NZsmTRsWPH4k27cuWKbt26paxZs9qpKgAAAAApjU1h6vjx4/r999/jTdu+fbuaNWumhg0batasWUlS3KM0adJEGzZs0KBBg/TXX39p9erV6tChgzJkyKCaNWu+sNcFAAAAgIfZdM3U999/r9SpU+v999+XJAUGBqpz587y8vLSa6+9pmHDhil16tTPdf1SYj7++GO5urrq119/1ZIlS+Tu7q4iRYrohx9+UPr06ZP89QAAAADgUWwKUydOnFCbNm2sj3/77TeZzWYtW7ZM3t7e+vzzzzV//vwXEqZMJpM++ugjffTRR0m+bgAAAAB4WjZ18wsPD5eXl5f18datW1WuXDl5e3tLksqVK6eLFy8mSYEAAAAA4IhsClOZMmXS2bNnJUnXr1/X0aNHVa5cOev8O3fuyGxOdmNbAAAAAMBTs6mbX5UqVfTLL78oOjpaBw8elKurq6pVq2adf/LkSWXPnj3JigQAAAAAR2NTmPr8888VEhKi3377TWnTptXQoUOVMWNGSVJERITWrFmjZs2aJWmhAAAAAOBIbApT7u7uGjVq1CPnubm5adu2bUqdOvVzFQYAAAAAjixJLmwKDw9XbGzsgxWazUqbNq1cXFySYtUAAAAA4JBsDlOHDx9WmzZtVLhwYZUqVUp79uyRJIWEhKhjx47avXt3khUJAAAAAI7GpjC1f/9+NW3aVBcvXlTt2rVlsVis87y9vRUREaEFCxYkWZEAAAAA4GhsClNjxoxR7ty5tXr1anXv3j3B/FKlSungwYPPXRwAAAAAOCqbwtThw4dVv359ubq6ymQyJZjv4+OjmzdvPndxAAAAAOCobApTzs7O8br2/VdQUJDc3NxsLgoAAAAAHJ1NYapw4cJau3btI+dFRkZq6dKlKlGixHMVBgAAAACOzKYw1bVrVx05ckTt2rXTtm3bJEknT57UokWLVL9+fYWEhKhTp05JWigAAAAAOBKbW6amTJmiixcv6ptvvpEkDRs2TH369JHFYtGUKVPk7++fpIUCAAAAgCNxtvWJZcqU0dq1a3X8+HFduHBBhmEoe/bsKlCgwCMHpQAAAACAV4nNYSpOvnz5lC9fvqSoBQAAAACSDZu6+f3+++8KCAhIdH7Pnj21evVqm4sCAAAAAEdnU5iaOXOmXF1dE52fKlUqzZo1y+aiAAAAAMDR2RSmzp8//9iuff7+/jp37pzNRQEAAACAo7MpTBmGofDw8ETnh4WFKSYmxuaiAAAAAMDR2RSm3nrrLf3++++Kjo5OMC86OlorV65kUAoAAAAArzSbwlTbtm11+vRpffzxx9q0aZMCAwMVGBiojRs3qkWLFjpz5ozatWuX1LUCAAAAgMOwaWj0ihUravDgwRo8eLA+++wz63TDMOTu7q6BAwfq3XffTaoaAQAAAMDh2Hyfqfr166t69erasWOHLl26JEnKkSOHypUrJw8PjyQrEAAAAAAc0XPdtNfDw0M1atRIqloAAAAAINl4rjAVERGhq1evKiwsTIZhJJhfokSJ51k9AAAAADgsm8LUrVu3NHDgQK1bt06xsbGSHlwvZTKZ4v3/8ePHk65SAAAAAHAgNoWpPn36aPPmzWrRooWKFy8uT0/PpK4LAAAAAByaTWFqx44datmypb7++uukrgcAAAAAkgWb7jOVOnVqZc2aNalrAQAAAIBkw6YwVbt2bW3YsCGpawEAAACAZMOmbn41atTQ33//rTZt2qhx48bKnDmznJycEiyXP3/+5y4QAAAAAByRTWGqadOm1v//66+/EsxnND8AAAAArzqbwtTQoUOTug4AAAAASFZsClP16tVL6joAAAAAIFmxaQCKh12/fl0nTpxQZGRkUtQDAAAAAMmCzWFqw4YNeu+991SxYkXVq1dPBw8elCSFhISobt26Wr9+fZIVCQAAAACOxqYwtWnTJnXp0kXp06fXZ599JsMwrPO8vb3l4+OjpUuXJlmRAAAAAOBobApTEyZMUPHixfXrr7+qWbNmCeYXKVKEkfwAAAAAvNJsClOnT59WzZo1E52fMWNGBQcH21wUAAAAADg6m8JUmjRpdPfu3UTnBwYGysvLy9aaAAAAAMDh2RSmSpUqpeXLlysmJibBvBs3bmjhwoV65513nrs4AAAAAHBUNoWpbt266dq1a/rwww+1YMECmUwm/fnnnxozZow++OADGYahzz77LKlrBQAAAACHYVOYyp07t3799Vd5eXlp7NixMgxDP//8s3766Sf5+vpq3rx5ypYtW1LXCgAAAAAOw/lZn3D//n2dPXtWXl5emjlzpm7fvq2LFy/KMAxlz55d3t7eL6JOAAAAAHAoz9wyZTab1aBBA61bt06SlC5dOhUqVEiFCxcmSAEAAABIMZ45TDk5OSlLliyKjo5+EfUAAAAAQLJg0zVTzZs318KFCxUaGprE5QAAAABA8vDM10xJksVikaurq6pVq6YaNWooa9asSp06dbxlTCaTWrVqlRQ1AgAAAIDDsSlMDR8+3Pr/ixcvfuQyhCkAAAAArzKbwtTGjRuTug4AAAAASFaeOUzdu3dPs2fPVqlSpVS5cuUXURMAAAAAOLxnHoAiderUWrBggYKDg19EPQAAAACQLNg0ml/+/Pl16tSppK4FAAAAAJINm8JUr169tHr1ai1atEgxMTFJXRMAAAAAODybBqAICAiQyWRS3759NWjQIPn4+ChVqlTxljGZTFqxYkWSFAkAAAAAjsamMOXl5SUvLy+9+eabSV0PAAAAACQLNoWpOXPmJHUdAAAAAJCs2HTNFAAAAACkdDa1TP39999PtVyJEiVsWT0AAAAAODybwlSLFi1kMpmeuNzx48dtWT0AAAAAODybwtTs2bMTTIuNjdWVK1e0cOFCWSwWffHFF89dHAAAAAA4KpvCVMmSJROdV79+fTVt2lR79uxRmTJlbC4MAAAAABxZkg9AYTabVatWLS1atCipVx3PsmXLVLduXRUsWFClSpXSp59+qnv37r3Q1wQAAACAODa1TD3J7du3FR4e/iJWLUmaNGmSpk6dqg4dOqhIkSK6deuWdu7cqdjY2Bf2mgAAAADwMJvC1NWrVx85PSwsTHv37tXPP/+s4sWLP1dhiTl37pzGjx+viRMnqmLFitbpNWrUeCGvBwAAAACPYlOYqly5cqKj+RmGoSJFiqh///7PVVhili5dqmzZssULUgAAAADwstkUpoYMGZIgTJlMJnl6eipHjhzKkydPkhT3KAcPHpSvr68mTpyoOXPmKDw8XAUKFFDPnj1VuHDhF/a6AAAAAPAwm8JU/fr1k7qOp3bjxg0dOXJEp06dUr9+/ZQmTRpNnjxZrVu31rp165QhQwab1+3snOTjcTwzJyf714AH2BaJi/ts+IxebWznVx/bOGVgO7/62Mb2Y1OYCg0N1bVr1+Tv7//I+SdPnlTmzJmVLl265yruUQzDUGRkpMaOHWt9/cKFC6ty5cr65Zdf1K1bN5vWazablD69e1KWimTO0zONvUtweHxGKQPb+dXHNk4Z2M6vPrbxy2dTmBo6dKjOnz+vhQsXPnJ+v379lCtXLg0ZMuS5insUT09PeXl5xQtyXl5eeuutt3TmzBmb12uxGAoLi0yKEp+Lk5OZL4KDCAu7q9hYi73LcEhx+ymf0auN7fzqYxunDGznVx/bOGl5eqZ56lY+m8LUrl279NFHHyU6v1KlSpo/f74tq36iPHny6NKlS4+cFxUV9Vzrjolh58P/iY21sE88AZ9RysB2fvWxjVMGtvOrj2388tnUsTIkJETp06dPdL6Xl5eCg4NtLupxKlWqpNDQUB0/ftw67datWzp69Kjy58//Ql4TAAAAAP7LppapTJky6dixY4nOP3r0qLy9vW0u6nGqVq2qggULqmvXrurevbtSpUqlKVOmyNXVVU2bNn0hrwkAAAAA/2VTy1TVqlW1ZMkSbdy4McG8DRs2aOnSpapatepzF/coZrNZU6ZMUZEiRdS3b1/16NFDHh4emjt3rjJlyvRCXhMAAAAA/sumlqkuXbpo586d6ty5s/z9/ZU3b15J0unTp3XixAnlzp1bXbt2TdJCH+bt7a3vv//+ha0fAAAAAJ7EppaptGnTasGCBerYsaNiYmK0du1arV27VjExMerUqZMWLlwoT0/PpK4VAAAAAByGTS1TkuTm5qauXbu+0BYoAAAAAHBUNrVMxcTEKCIiItH5ERERiomJsbkoAAAAAHB0NoWpQYMGqUmTJonO/+ijjzRs2DCbiwIAAAAAR2dTmNq+fbtq1KiR6PwaNWpo27ZtNhcFAAAAAI7OpjB1/fp1+fj4JDr/tddeU1BQkM1FAQAAAICjsylMeXl56fz584nOP3v2rDw8PGwuCgAAAAAcnU1hqnz58po/f76OHTuWYN7Ro0e1cOFCVahQ4bmLAwAAAABHZdPQ6N26ddP27dvVsGFDVa5cWXny5JH04Ka9mzdvlre3t7p165akhQIAAACAI7EpTPn4+GjJkiUaNWqUNm7cqPXr10uSPDw89MEHH6h79+6PvaYKAAAAAJI7m2/a+9prr2n48OEyDEMhISGSJG9vb5lMpiQrDgAAAAAclc1hSpIiIyMVEREhd3d3ubu7J1VNAAAAAODwnjlMXb58WdOmTdPWrVt17do163QfHx9VqlRJrVu3Vvbs2ZO0SAAAAABwNM80mt+GDRtUu3ZtzZ8/X2azWZUqVdL777+vSpUqycnJSb/++qtq166tDRs2vKh6AQAAAMAhPHXL1JkzZ9S9e3dlz55dAwYMUPHixRMss3fvXvXr1089evTQ0qVLraP8AUBKZDabZDYn3+tInZzM8f5NjiwWQxaLYe8yAACvqKcOU5MnT1b69Ok1b948eXl5PXKZ4sWLa+7cuapdu7Z++uknff/990lVJwAkK2azSV5ebsk6iMTx9Exj7xJsFhtrUWhoJIEKAPBCPHWY2r17txo2bJhokIrj5eWlBg0aaPHixc9bGwAkW2azSU5OZo2cu0+Xg8LtXU6KlM0nrb5sVkxms4kwBQB4IZ46TIWGhipr1qxPtWy2bNkUGhpqa00A8Mq4HBSus1du27sMAADwAjx1/5P06dPr8uXLT7Xs5cuXlT59epuLAgAAAABH99RhqmTJklq8ePETW5xCQ0O1ePFilSxZ8nlrAwAAAACH9dRhqkOHDgoNDVXz5s21f//+Ry6zf/9+tWjRQqGhoWrfvn2SFQkAAAAAjuapr5nKkyePRo0apW+++UbNmjVT1qxZ5e/vL3d3d925c0cnT57U5cuXlSpVKn3//ffKmzfvi6wbAAAAAOzqqcOUJFWvXl358uXT1KlTtWXLlng3582UKZMaNmyoNm3aKGfOnEleKAAAAAA4kmcKU5KsN+2VpIiICN25c0fu7u7y8PBI8uIAAAAAwFE9c5h6mIeHByEKAAAAQIr01ANQAAAAAAD+D2EKAAAAAGxAmAIAAAAAGzzVNVMRERFKkyaNnJycXnQ9AAAADsVsNslsNtm7DJs5OZnj/ZscWSyGLBbD3mUACTxVmCpRooRGjBihDz74QJLUs2dPNWnSRIULF36hxQEAANiT2WySl5dbsg4icTw909i7BJvFxloUGhpJoILDeaow5eLioujoaOvjZcuWqWzZsoQpAADwSjObTXJyMmvk3H26HBRu73JSpGw+afVls2Iym02EKTicpwpTuXLl0qJFi5Q1a1alTZtWknTlyhUdPXr0sc/Lnz//81cIAABgZ5eDwnX2ym17lwHAwTxVmOrRo4e6d++uTz75RJJkMpk0duxYjR079pHLG4Yhk8mk48ePJ12lAAAAAOBAnipMVahQQRs3btThw4cVHBysgIAANWrUSEWLFn3R9QEAAACAQ3qqMCVJXl5eKl++vCRpyZIlqlmzpsqUKfPCCgMAAAAAR/bUYephc+bMSeo6AAAAACBZsSlMSQ/uPTVz5kxt2bJFV69elSRlyZJF7777rlq1aiUPD48kKxIAAAAAHI1NN00ICgpS3bp1NX78eEVGRurtt9/W22+/rbt372r8+PGqV6+erl+/ntS1AgAAAIDDsKllauTIkbp586Z++uknVaxYMd68rVu36vPPP9eoUaM0fPjwJCkSAAAAAByNTS1T27dvV8uWLRMEKUmqWLGiWrRooa1btz53cQAAAADgqGwKU3fv3lWGDBkSnZ8xY0bdvXvX5qIAAAAAwNHZFKZy586tVatWKTo6OsG8+/fva9WqVcqdO/dzFwcAAAAAjsqma6batm2r7t27q2HDhmratKneeOMNSdL58+c1f/58nTx5UmPGjEnKOgEAAADAodgUpmrWrKm7d+9q1KhR6tevn0wmkyTJMAxlyJBBQ4YM0XvvvZekhQIAAACAI7H5PlP169dX7dq1deTIkXj3mSpQoICcnW1eLQAAAAAkC8+VepydnVWkSBEVKVIkicoBAAAAgOTBpgEoAAAAACClI0wBAAAAgA0IUwAAAABgA8IUAAAAANiAMAUAAAAANniu0fwOHDig3bt3Kzg42Hrz3rt37+rcuXN644035O7unlR1AgAAAIBDsSlMRUdHq0ePHtq4caMMw5DJZFKlSpX0xhtvyGw2q3Xr1mrVqpU6duyY1PUCAAAAgEOwqZvf2LFjtWXLFn333Xdas2aNDMOwzkuVKpXee+89bdy4McmKBAAAAABHY1OYWrVqlZo0aaLGjRsrXbp0Cebnzp1bgYGBz10cAAAAADgqm8JUcHCw/Pz8Ep3v5OSke/fu2VwUAAAAADg6m8LU66+/rnPnziU6f//+/cqRI4fNRQEAAACAo7MpTL3//vuaP3++/vnnH+s0k8kkSVq4cKH++OMP1a1bN0kKBAAAAABHZNNofh06dNDBgwfVvHlz5cqVSyaTSUOHDtXt27d17do1VaxYUa1atUriUgEAAADAcdgUplxdXTVt2jStWLFCa9eulcViUXR0tPz8/PT555+rTp061pYqAAAAAHgV2XzTXpPJpDp16qhOnTpJWQ8AAAAAJAs2XTMFAAAAACmdTS1TH3/88WPnm0wmpUqVSpkzZ1apUqVUo0YNOTvb3AgGAAAAAA7HpoRjGIaCgoJ06dIlpUuXTlmzZpUkXblyRbdv31bOnDnl4eGhgwcPauHChZoyZYpmzJghb2/vJC0eAAAAAOzFpm5+3bp10+3btzVs2DD99ddfWrp0qZYuXaq//vrLOqpfnz59tGvXLg0ZMkRnzpzR6NGjk7p2SdKdO3dUoUIF+fn56fDhwy/kNQAAAADgv2wKUyNGjFD9+vVVt25dOTk5Wac7OTmpXr16qlevnoYOHSqTyaT69eurQYMG2rJlS1LVHM/EiRMVGxv7QtYNAAAAAImxKUydPHlS2bJlS3R+tmzZdOLECevj/Pnz6/bt27a81GOdPXtW8+bNU5cuXZJ83QAAAADwODaFqUyZMmnNmjWyWCwJ5lksFv3xxx/KmDGjdVpoaKjSpUtne5WJGDRokJo0aaI333wzydcNAAAAAI9j0wAUn3zyiQYOHKiPPvpIDRs2VI4cOSRJFy9e1KJFi3T48GF9++231uXXrFmjQoUKJU3FD63z1KlTGjdunI4ePZok63R2tv9I8U5O9q8BD7AtEhf32fAZJY7PxnGwLRLHd/nJ+GwcB9sicXyX7cemMNWsWTOZTCb9+OOP+vbbb2UymSQ9GOXPy8tL3377rZo1ayZJio6OVs+ePa0j/iWFu3fvatiwYerevbs8PDySZJ1ms0np07snybrwavD0TGPvEhwenxGSA/bTJ+MzQnLAfvpkfEYvn803f2ratKkaNmyoI0eO6OrVq5KkLFmyqECBAnJxcbEu5+rqqpIlSz5/pQ+ZNGmSMmTIoAYNGiTZOi0WQ2FhkUm2Pls5OZn5IjiIsLC7io1N2JUV/7ef8hklju+y42A/TRzf5Sfju+w42E8Tx3c5aXl6pnnqVr7nupOui4uLihYtqqJFiz7Pap7JlStXNH36dE2YMEHh4eGSpMjISOu/d+7ckbu7bS1MMTHsfPg/sbEW9okn4DNCcsB++mR8RkgO2E+fjM/o5XuuMHX//n2dO3dO4eHhMgwjwfwSJUo8z+of6fLly7p//77atWuXYN7HH3+swoULa+HChUn+ugAAAADwMJvClMVi0ahRozRv3jzdu3cv0eWOHz9uc2GJyZcvn2bPnp3gdYYOHar+/furYMGCSf6aAAAAAPBfNoWpyZMn6+eff1bjxo1VrFgxff311/ryyy/l6empefPmyWQy6auvvkrqWiVJnp6eKlWq1CPn5c+fX/nz538hrwsAAAAAD7Np/MRly5apZs2a6t+/v8qXLy/pQZBp1KiRFi5cKJPJpF27diVpoQAAAADgSGwKU9euXVPp0qUlPRitT3owBHrc49q1a+u3335LohKfrFSpUjp58iRd/AAAAAC8NDaFKS8vL+sIeu7u7vLw8FBgYGC8ZcLCwp6/OgAAAABwUDZdM/XWW2/p8OHD1selSpXSrFmzlC9fPhmGodmzZ8vPzy/JigQAAAAAR2NTy1SjRo0UHR1t7drXvXt3hYWFqXnz5mrevLnu3LmjgICAJC0UAAAAAByJTS1TVapUUZUqVayP8+TJow0bNmj37t1ycnJS0aJF5eXllVQ1AgAAAIDDsall6u+//1ZISEi8aWnTplXVqlVVqVIlWSwW/f3330lSIAAAAAA4IpvC1Mcff6wdO3YkOn/Xrl36+OOPbS4KAAAAABydTWHKMIzHzo+OjpaTk5NNBQEAAABAcvDU10xdvXpVV65csT4+d+7cI7vyhYWFaf78+cqSJUvSVAgAAAAADuipw9TSpUs1fvx4mUwmmUwmTZ48WZMnT06wnGEYcnJyUv/+/ZO0UAAAAABwJE8dpmrWrKm8efPKMAx9/vnnatGihYoXLx5vGZPJpDRp0ihfvnzKmDFjkhcLAAAAAI7iqcNU7ty5lTt3bknS0KFDVbx4cWXPnv2FFQYAAAAAjsym+0zVq1cvqesAAAAAgGTFpjAlSWfPntWSJUt0+fJl3b59O8EIfyaTSbNmzXruAgEAAADAEdkUppYvX65evXrJ2dlZb775pjw9PRMs86Th0wEAAAAgObMpTI0fP1758uXT1KlT5e3tndQ1AQAAAIDDs+mmvdevX1eDBg0IUgAAAABSLJvClJ+fn65fv57UtQAAAABAsmFTmAoICNDixYu1f//+pK4HAAAAAJIFm66Zmjp1qtKmTatmzZopT548ev3112U2x89lJpNJkyZNSpIiAQAAAMDR2BSmTp06JUl6/fXXdefOHZ05cybBMiaT6fkqAwAAAAAHZlOY2rRpU1LXAQAAAADJik3XTAEAAABASmdTy5QkxcbGas2aNdq9e7eCg4PVtWtX+fn5KTw8XDt37tTbb7+tjBkzJmWtAAAAAOAwbApTYWFh+vTTT3Xo0CG5ubnp7t27at68uSTJzc1NgwYNUt26ddWjR48kLRYAAAAAHIVN3fxGjhyp06dP6+eff9aGDRtkGIZ1npOTk2rUqKGtW7cmWZEAAAAA4GhsClMbN25UixYtVK5cuUeO2vfGG2/oypUrz10cAAAAADgqm8JUeHi4smXLluj8mJgYxcbG2lwUAAAAADg6m8JUjhw5dPTo0UTn79ixQ7lz57a5KAAAAABwdDaFqQ8//FBLlizR6tWrrddLmUwmRUdHa8yYMdq+fbsaN26cpIUCAAAAgCOxaTS/li1b6syZM+rRo4c8PT0lSV9++aVCQ0MVExOjxo0bq2HDhklaKAAAAAA4EpvClMlksg5/vnbtWl28eFEWi0U5cuRQzZo1VaJEiaSuEwAAAAAcis037ZWk4sWLq3jx4klVCwAAAAAkGzZdMxUYGKhNmzYlOn/Tpk26fPmyzUUBAAAAgKOzqWVqxIgRioiIUOXKlR85f+7cufL09NSYMWOeqzgAAAAAcFQ2tUz9888/Klu2bKLzy5Qpo71799pcFAAAAAA4OpvCVFhYmNzd3ROd7+bmptDQUFtrAgAAAACHZ1OYev3117V///5E5+/bt0+ZM2e2uSgAAAAAcHQ2han3339fq1at0uzZs2WxWKzTY2NjNWvWLK1evVrvv/9+khUJAAAAAI7GpgEo2rdvr3379mnIkCGaPHmy3nzzTUnS+fPnFRISopIlS6pjx45JWigAAAAAOBKbwpSrq6umT5+uZcuWaf369bp06ZIkqVChQqpevbrq1q0rs9mmRi8AAAAASBaeOUzdu3dPY8aMUalSpdSgQQM1aNDgRdQFAAAAAA7tmZuPUqdOrQULFig4OPhF1AMAAAAAyYJNffHy58+vU6dOJXUtAAAAAJBs2BSmevXqpdWrV2vRokWKiYlJ6poAAAAAwOHZNABFQECATCaT+vbtq0GDBsnHx0epUqWKt4zJZNKKFSuSpEgAAAAAcDQ2hSkvLy95eXlZh0QHAAAAgJTGpjA1Z86cpK4DAAAAAJIVbgYFAAAAADawOUxFRERoypQpatOmjerWratDhw5JkkJDQzVjxgxdvHgxyYoEAAAAAEdjUze/a9euqXnz5rp27Zpy5sypc+fO6c6dO5IeXE81f/58XblyRd9++22SFgsAAAAAjsKmMDVixAjduXNHy5cvl7e3t8qWLRtvftWqVbVly5akqA8AAAAAHJJN3fx27NihFi1aKE+ePDKZTAnmZ8+eXf/+++9zFwcAAAAAjsqmMHXv3j15e3snOj+uyx8AAAAAvKpsClO5c+fW33//nej8DRs26K233rK5KAAAAABwdDaFqZYtW2r16tWaMmWKIiIiJEmGYejixYv66quvdODAAbVq1Sop6wQAAAAAh2LTABR16tTR1atXNXbsWP3www+SpE8//VSGYchsNqt79+6qWrVqUtYJAAAAAA7FpjAlSR07dlSdOnW0bt06Xbx4URaLRTly5FD16tWVPXv2pKwRAAAAABzOM4WpqKgobdy4UZcvX5aXl5feffdduvMBAAAASJGeOkwFBwerSZMmunz5sgzDkCSlSZNGEyZMSHCfKQAAAAB41T31ABQTJ07UlStX1KpVK/3000/q1auXUqVKpb59+77I+gAAAADAIT11y9Sff/6pOnXq6JtvvrFOy5gxo7744gudO3dOuXLleiEFAgAAAIAjeuqWqX///VfFihWLN61YsWIyDEPBwcFJXhgAAAAAOLKnDlPR0dFKlSpVvGmurq6SpJiYmKStCgAAAAAc3DON5nflyhUdPXrU+jg8PFySdPHiRXl6eiZYPn/+/M9ZHgAAAAA4pmcKU2PHjtXYsWMTTO/fv3+8x4ZhyGQy6fjx489X3SP88ccfWrFihY4ePaqwsDDlzJlTLVq0UIMGDWQymZL89QAAAADgUZ46TA0dOvRF1vHUZs6cqaxZsyogIEDp06fXX3/9pT59+ujatWvq3LmzvcsDAAAAkEI8dZiqV6/ei6zjqU2aNEne3t7Wx2XKlFFoaKhmzJihTp06yWx+6svAAAAAAMBmyS55PByk4uTLl08RERGKjIy0Q0UAAAAAUqJnumbKUe3bt08+Pj7y8PB4rvU4O9s/Wzo52b8GPMC2SFzcZ8NnlDg+G8fBtkgc3+Un47NxHGyLxPFdtp9kH6b27t2r1atXx7uZsC3MZpPSp3dPoqrwKvD0TGPvEhwenxGSA/bTJ+MzQnLAfvpkfEYvX7IOU9euXVP37t1VqlQpffzxx8+1LovFUFiY/bsJOjmZ+SI4iLCwu4qNtdi7DIcUt5/yGSWO77LjYD9NHN/lJ+O77DjYTxPHdzlpeXqmeepWvmQbpsLCwtS2bVt5eXlp3LhxSTLwREwMOx/+T2yshX3iCfiMkBywnz4ZnxGSA/bTJ+MzevmSZZi6d++e2rdvr/DwcC1YsEBp06a1d0kAAAAAUphkF6ZiYmL0+eef69y5c5o7d658fHzsXRIAAACAFCjZhan+/ftr8+bNCggIUEREhA4cOGCd99Zbb8nV1dV+xQEAAABIMZJdmNqxY4ckadiwYQnmbdy4UdmyZXvZJQEAAABIgZJdmNq0aZO9SwAAAAAAcWcvAAAAALABYQoAAAAAbECYAgAAAAAbEKYAAAAAwAaEKQAAAACwAWEKAAAAAGxAmAIAAAAAGxCmAAAAAMAGhCkAAAAAsAFhCgAAAABsQJgCAAAAABsQpgAAAADABoQpAAAAALABYQoAAAAAbECYAgAAAAAbEKYAAAAAwAaEKQAAAACwAWEKAAAAAGxAmAIAAAAAGxCmAAAAAMAGhCkAAAAAsAFhCgAAAABsQJgCAAAAABsQpgAAAADABoQpAAAAALABYQoAAAAAbECYAgAAAAAbEKYAAAAAwAaEKQAAAACwAWEKAAAAAGxAmAIAAAAAGzjbuwAAAADA3sxmk8xmk73LsImTkznev8mVxWLIYjHsXcYzIUwBAAAgRTObTfLyckv2YcTTM429S3gusbEWhYZGJqtARZgCAABAimY2m+TkZNbIuft0OSjc3uWkSNl80urLZsVkNpsIUwCejO4E9pccuxMAAF6cy0HhOnvltr3LQDJCmALsgO4EjiE5dicAAACOgzAF2AHdCewvuXYnAAAAjoMwBdgR3QkAAACSr+TdxwgAAAAA7IQwBQAAAAA2IEwBAAAAgA0IUwAAAABgA8IUAAAAANiAMAUAAAAANiBMAQAAAIANCFMAAAAAYAPCFAAAAADYgDAFAAAAADYgTAEAAACADQhTAAAAAGADwhQAAAAA2IAwBQAAAAA2IEwBAAAAgA0IUwAAAABgA8IUAAAAANiAMAUAAAAANnC2dwEAACRnZrNJZrPJ3mXYxMnJHO/f5MpiMWSxGPYuA0AKRJgCAMBGZrNJXl5uyT6MeHqmsXcJzyU21qLQ0EgCFYCXjjAFAICNzGaTnJzMGjl3ny4Hhdu7nBQpm09afdmsmMxmE2EKwEtHmAIA4DldDgrX2Su37V0GAOAlS979EgAAAADATghTAAAAAGADwhQAAAAA2CBZhqmzZ8/qk08+UZEiRVSuXDmNGDFC0dHR9i4LAAAAQAqS7AaguH37tlq2bKk33nhD48aNU1BQkIYNG6Z79+6pb9++9i4PAAAAQAqR7MLU/PnzdefOHY0fP15eXl6SpNjYWPXv31/t27eXj4+PfQsEAAAAkCIku25+27ZtU5kyZaxBSpJq1qwpi8WiHTt22K8wAAAAAClKsgtT586dU65cueJN8/T0VKZMmXTu3Dk7VQUAAAAgpTEZhpGsbheeP39+devWTe3atYs3/f3331fRokU1cOBAm9ZrGIZD3DndZJLMZrNCw6MUE2uxdzkpkrOTWV5pU8lisehFfTvYzvb3orcz29j++C6nDHyXX318l1OGl7Gdn5bZbJLJZHqqZZPdNVMvislkkpPT031oL4NX2lT2LiHFM5tffMMt29n+XvR2ZhvbH9/llIHv8quP73LK8DK2c1JKXtXqQZe+8PDwBNNv376tdOnS2aEiAAAAAClRsgtTuXLlSnBtVHh4uG7cuJHgWioAAAAAeFGSXZiqUKGC/vrrL4WFhVmnrVmzRmazWeXKlbNjZQAAAABSkmQ3AMXt27dVq1Ytvfnmm2rfvr31pr0ffPABN+0FAAAA8NIkuzAlSWfPntXAgQP1zz//yN3dXXXq1FH37t3l6upq79IAAAAApBDJMkwBAAAAgL0lu2umAAAAAMAREKYAAAAAwAaEKQAAAACwAWEKAAAAAGxAmAIAAAAAGxCmAAAAAMAGhCkAAAAAsAFhCgAAAABsQJgCAABPZBiGvUsAAIdDmMJLY7FY4j3mhxlIOfi+J1+xsbGSJJPJZOdKAMDxEKbwUsTGxspsfrC7XbhwQVFRUfww46k8/Ef4vXv37FgJnkXcH+Bx4r7vhKrkw2KxaNWqVdq8ebN1WteuXbV9+3Y7VoWX4f79+/YuAUg2nO1dAF59sbGxcnJykiT17dtXN2/eVMWKFdWwYUNrwAIexTAM6x/hW7du1e7du1W+fHmVKVPGzpXhcR7+zs+bN0+BgYFydXVV2bJlVapUKTtXh6dlMpl06tQpTZkyRSNHjtTKlSv1999/q3379vYuDUnEYrFo69atiomJUbVq1SRJQ4cO1TvvvKPy5cvbuTo4sod/n1M6whReuLg/qj7//HMdOnRIXbt2VZkyZQhSeKK4A/XSpUs1aNAg1alThzOmDs4wDOt3vmvXrjp8+LC8vb1lNps1ZcoUtWvXTh9++KGyZ89u50rxJCaTSd27d9f169fVq1cvpU6dWlOmTFH+/PntXRqSSFRUlNauXav9+/fr3r17WrVqlfbt26cPP/zQ3qXBgT0cpI4eParg4GDdvn1bFSpUkLu7u5ydnVNU2CJM4aVYuXKl9u3bp++//14lS5YkSCFR/z0A//333xoxYoS6dOmiBg0ayNPT047V4Unitt306dN16NAhjRw5Uv7+/vLw8NAPP/ygyZMnq2DBgsqaNSvHgWTCyclJUVFRkqSLFy8qf/78Sp06tZ2rwvOwWCyKiYlRmjRp9M0336h9+/YaMGCAnJycNH36dOXNm9feJcKBxR3nlyxZopEjR8rZ2VkRERHKkCGDPvnkE7333nvKkCGDnat8efglQ5K6e/euTp06lWD6xYsX5ebmpoIFC8b7A+q/109wPQX+eybr4MGDSp8+vapVq0aQSkaOHz+uIkWKqHDhwvLw8ND58+e1cOFC1axZU+XLlydIJSMff/yxli5dqmrVqmnAgAH6/fffFRkZae+yYKOoqCi1adNGGzduVGRkpNKnTy9vb29FRkbK3d1dJ0+etC7734GjgDg7duzQ4MGD1aFDB02dOlX79+9XiRIl9P3332vlypUJrpt9lfFrhiRz//59tW/fXsuWLUtwAA4LC9OdO3fk7u4u6f8O0A9fDxMZGZlimoSR0PDhwzVq1Cjr47h95NixY3J2dla2bNniTY8TFBT08orEU7FYLAoNDZXFYpGLi4vOnz+vxo0bq1SpUho8eLBSpUqlH3/8UQcPHrR3qfiPR/0B5Ovrq7feektDhw5VlSpVNGjQIK1evdo6IMy9e/d04sSJl10qbHT//n3dvHlTw4YN065duyRJjRs31qRJk5Q+fXpNnz5dixYtkiSZzWZOcuKRDh48qAIFCuh///uf/P39ZTKZFBoaKh8fH5UrV05OTk4pJowTppBkXFxc1LJlS3Xu3Flms1lXr161znvrrbd07949/frrr4qJiYl3VvrEiRNauXKljh07Zo+y4QDCw8NlsVhUsWJF67S4faRYsWIKDAzUzp07rdPjftwvX76s8ePHxzuTipfrUbc8MJvNypo1q44dO6a9e/eqSZMmKlOmjAYOHCg3NzcFBgZq3759+ueff1LMj21y8PDAIcuWLdOoUaM0ZswY7d27V9KDY/ywYcNUpUoVDR48WMuXL9fx48c1ZMgQtWjRQuHh4fYsH0/Jw8NDc+fOVY4cOfTtt99q8+bNeuedd1ShQgVNmDBBbm5umjFjhjVQmUwmRUVF6cSJE4qOjrZz9bCHR51kOXr0qCIjI5UpUyZJ0qeffqpjx45p7Nixyps3r/755x8dPnz4ZZdqF4QpJIm4P26rVKkid3d3jRkzRp07d9aRI0ckSdWqVdObb76pqVOnatWqVdbnXb9+XbNnz9axY8eUI0cOu9QO+0ubNq2++OILFS9eXFu2bNGAAQOs83x9fZU5c2b98ssv1v3JZDLp/v37+uuvv3TgwAEGpbCTh295EBYWpoiICGvrcseOHWUYhpo3b65SpUpp5MiR8vDw0M2bNzVx4kTdvHlT1apVo7ufg7BYLPEGC5o0aZL27t2ro0ePqlWrVlq7dq2k/wtU1atX13fffacuXbpo8+bNmj59utKmTWvPt4CnEPdb7enpqQkTJih37tz69ttvtX37dt29e1c+Pj4aP3683N3dNXPmTM2bN09BQUEaNGiQ+vfvb712DinD6dOnde3aNeuxYceOHTp06JAkqUCBAoqKitLFixfVrl07nTlzRpMnT5a/v79u3bqlWbNmac+ePYqJibHnW3gpTAbtt0gCD5/RlKRp06ZpyZIlypYtm7p06aJChQopLCxMzZo1U3BwsHLmzKksWbLoypUrOn/+vGbNmiV/f387vgPYS9yAE4ZhKDo6WgMHDtTatWvVoEEDBQQESJLmzp2rSZMmKVu2bGrSpInSp0+vI0eOaNq0afrss8/06aef2vldpDwPDxTSr18/HTlyRMHBwWrdurUqV66sbNmyacOGDRo1apScnJzUvn17Xb9+XQcOHNDu3bs1e/ZsvvMOaNCgQdq6dauGDRumYsWKaeTIkZo2bZokafDgwWrQoIF12ZUrVyomJkbFixdndMZkwGKxJDh5ERYWps8++0znz5/XgAEDVKZMGaVJk0bXrl1T9+7dde7cOXl4eCgqKkqTJk1SwYIF7VQ9XraQkBBNnz5de/bs0dSpU7V9+3b17t1bP/zwgypVqqT9+/fr448/loeHh9zc3PTTTz8pb968un//vn7//XdNmDBBPXv2VJUqVez9Vl44whSS1JIlS6w/tgsWLNCMGTOUNWtWde3aVYULF1ZERIR1lK/IyEj5+fmpRYsWypUrl50rh73duHFDmTJl0r///quff/5Z69atU/Xq1fXtt99KetDtaPny5dq9e7dcXFyUI0cONWzYUK1atZLEPS9epodPnvTu3Vt//fWXqlWrpps3b+qPP/5Q/fr11a5dO+XMmVMnTpzQ0KFDFRISotjYWOXLl08dOnRgtDAHdPr0aQ0dOlQNGjRQrVq19PPPP2v06NHq2bOnDhw4oN9//12jRo1SrVq17F0qnkOfPn1UunRp63ZMLFDdvHlT69atU1RUlCpXrqycOXPauXK8bEuXLtWsWbMUGRmpq1ev6rvvvlOdOnXk4uIik8mklStX6quvvlL58uXVvn17ubu7688//9TEiRPVsWNHtWvXzt5v4eUwgCQyb948o2TJksadO3es0+bPn2/UqFHDaN26tXHgwAHDMAzDYrFY/437f6Rs27ZtMypVqmQEBwcbhmEY165dM7777jujfPnyxsCBA63LBQcHGxcuXDDOnDljXL161To9Njb2pdcMwwgPDzeGDx9ubN++3YiJiTEM48FxoFChQsZXX31lnDlzxrpsUFCQERERYURFRdmrXDzBzZs3jWXLlhnh4eHG+vXrjbfffttYsmSJYRiGsWfPHsPPz8946623jIULF9q5UtgqJCTEaNOmjVGwYEFj/fr11um3b982mjdvbpQrV87YuHGjERkZaccq4Uj69etn+Pn5GZUqVTJOnjxpGIZhxMTEWP9+++OPP4xKlSoZ5cuXN0qUKGHUqVPHmDFjhvX5KeH3mZYpJJnNmzerS5cu+u2335Q7d27r9IdbqLp3764CBQrYsUo4orlz52rChAnatGmT9f41QUFBmjx5sjZu3Bivheq/DFqk7GLUqFGaPn26Xn/9dY0fPz5el70FCxZoyJAhqlmzplq3bi1fX187VopHeVSXL0mKiIiQh4eHevXqpVu3bmnkyJHWUVibNWummzdvKjQ0VOvXr+dWBcnAo46PV65c0ZgxY7R27VqNGTNGVatWlfR/LVSBgYHq2bOnKlWqJFdXV3uUDQcQExMjwzA0ZMgQRUdH6/Dhw3J1ddXw4cOVO3du6zWzJpNJ165dU3h4uKKiopQhQwa9/vrrkhI/zrxqXv13iBfiUSO7ZMuWTalTp9bNmzclyTooQOPGjfXJJ5/o+vXrGjBgAEPopnCPOn9TqlQp3b1713pha2xsrHx8fNShQwdVqVJFmzZt0sCBAx+5PoKUfeTKlUuFChVScHCw9bseN9JX48aN1atXL61fv17jxo3TuXPn7Fkq/uPhgUNOnTqlkydP6sKFC5IejPRmGIZCQkIUHh4uFxcXSdLZs2dlNpvVu3dv/fHHHwSpZMBisViPjw8PHBF3YrN69erq3r27NmzYIOn/BqVIly6dxowZw8A+KdDDv8/Ozs5ycXHRN998o8GDB6tly5aKjo7WN998ozNnzsQb+tzNzU158+ZVgQIFrEHK+P8ju6YEKeNdIsnFXS/x66+/atmyZQoMDFSmTJmUOXNm7dmzR5KsP8LSgz+uGjRoIIvFwo9wChf3437+/Hndvn1bsbGx1qFV44J43IAUcYHqnXfe0ZIlS6xDNOPletTw5XXq1FGLFi2UKVMmdevWTTdv3pSrq2u8QNWtWzf9888/1pYN2N/Do/Z9/fXX6tq1qxo2bKjWrVtr0KBBioqKkslkUqFChXTq1ClNmTJFq1ev1owZMxQaGqr8+fPL29vbzu8CTyPuD9lhw4Zp3LhxioiIsM7LmjWrevTooapVq+qLL77Q5s2bJT0IVL/88ot+/vlnvrcpzMOtmFevXtWFCxd06dIl6/GiQYMGatGihe7fv6+AgABdvHhRTk5O2rBhg7799tsE93xMSSc66eYHm23ZskXffPONYmJiZDKZZDabFRYWpvLly6tcuXIqXry4PD09lSVLFjk7O0t60I2AMIXt27era9eucnZ2Vt68eVW4cGEtXLhQNWrUULt27ZQjR454Z7SCgoJ04cIFlSpVyo5Vp0wPDzZx+fJlubi4yGw2K1OmTLJYLFq3bp3GjBkjs9msOXPmKGPGjIqOjrZ2D+I775h69+6tHTt26JtvvlGqVKl0584d9ezZUxUrVtT3338vNzc3BQQEaNOmTTIMQ+nSpdO4ceOUL18+e5eOJ/hv176PP/5YFy9eVJMmTdSiRQt5eHhY5x0+fFidOnVSdHS0+vfvr/fee88eJcOB/P7775o4caLCw8N169YtNWrUSHXq1FHhwoUlSYsXL9acOXMUHBysKlWqaMmSJfrss8/UsWNHO1duP4QpPLVH9X0NDQ2VxWLRqVOndOHCBS1fvlzHjh1ThgwZFBwcLMMwlCVLFhUpUkTDhg1LUWcqkLhbt27p8OHDunTpki5cuKB//vlHFy9elMVi0f379/XGG28oa9asypMnj/Llyxdv9LCU0gfbETz8Wffu3VuHDh3S9evX9dprr6lJkyZq1qyZDMPQ2rVr9cMPP0iSfvnll3iBimvaHM/Zs2f1+eefq23btnrvvffk6uqqc+fOqU6dOqpVq5b69u0rNzc3SdI///wjJycnZc6cWa+99pqdK8eTPHzy4+ETGZ9//rn279+vJk2aWIezjtOuXTsdPHhQTk5OWrduXbx5SFlWrVqlb7/9Vm3atFHjxo21YMECTZkyRRUqVFDr1q319ttvS5LWrFmjtWvX6tq1a6pdu7Y++ugjSSn3GmZnexeA5OHhA3RISIju37+v9OnTy8vLS5JUunRplS5dWlFRUTp16pRWrFihK1eu6NKlSzpx4oRq1qyZIr9gePTBNX369KpQoYL1cXR0tMaOHauVK1eqb9++On78uA4cOKBNmzYpQ4YM8Z5LkHp54j7rr7/+Wrt371aXLl1ksVh048YNDRw4UIGBgfriiy9Uo0YNSdKECRNUu3Zt/f7779auYHzv7e+/9wGMjIzUpUuXlC5dOrm6uurChQtq0qSJqlWrpn79+ilNmjTatm2bKlSooKJFi9qxcjyLh7fz+PHjFRsbqxo1asjf318//PCDunXrpvnz58swDH3yySdyc3PT5cuXlTp1av3www/y8/MjSKVgZ8+e1Zw5c6xDmp88eVKzZs1SwYIFtWPHDkVFRalTp04qWrSo3nvvPVWvXl137tyx3qw7JZ/oJEzhiR7uYz9o0CDt2bNHQUFBypw5szp06KBSpUpZ/3DKmTOnnJ2dFRUVJX9/f/n7+6t69er2LB929HCQ+vPPP/XXX3/p0qVLKlasmMqXL688efJIklxdXVW0aFHNnz9fZcuWtY4uFTeyGOzn8OHDOnz4sPr06aOKFSvKxcVFp0+f1rhx4xQZGWm9yL169eq6d++efvnlF0VERHBdjYMwDMN6/P7888/VunVrubu7y2w2K1WqVNZuPGXLltWAAQOUJk0a/fnnn5o8ebKyZMli/Y7Csf13Ox8+fFgtWrRQ+vTprcuMHTtWn3/+uRYtWqRTp06pbNmy2rNnj06fPq08efLwnU3h7t+/r6xZs6pevXoKDAxU69atVbVqVQ0dOlRz587VwIEDlSZNGt2/f18lS5aU2Wy2BqmUNNjEo6Tcd46nFvcF+eKLL7Rx40b973//06effqpMmTLpyy+/1MyZM3X9+nVJUoECBXTv3j0dOHDAjhXDUcQFqaVLl6pLly76+++/df36dY0aNUoBAQH67bffrMumS5dOkZGRunLlinVaXJCiN7L9hIeH699//1WmTJnk4uKiixcvqlmzZqpVq5Z69uypVKlS6dixYzKbzapdu7ZmzpypHDly2Lts6EFLRdx3cOLEidq5c6du3bql3Llzq3z58urSpYsqV66sKlWqaPDgwfLw8FBISIhWrVold3d3ZcyY0c7vAE8rbjsPGTJEhw8f1ujRo9WwYUP5+PjIMAzFxMRIkn744Qf973//07lz5zR69GidOXNGY8aMsQ4ChJTL399fXbp0UaZMmTR16lS98cYb6tq1qySpfv36ypEjh3bv3q0JEyboxo0b8Z6b0nsg0DKFRD3cqrB//37t3btXvXr1snbpadu2rYYPH66ff/5ZWbJkUZMmTeTq6ipXV9cEo7og5Tp16pRGjhypjh07qnHjxkqXLp1OnDihb775RtOnT1fatGlVuXJl5c+fX5kyZdLhw4eVN2/eeOtI6Qfql+VR3TTu378vk8kkHx8f3bhxQw0bNozXirFmzRrrfaVef/11WhIdSFxLxdGjR3X27Fl1795dZcqUkSS1aNFCt2/f1r59+1SvXj05OzvrxIkTmjFjhrZu3apffvnF2o0bycOdO3d07Ngx1a5d2zpYQGBgoObOnavbt2+rUKFC+uijj/T111+rZcuWioiIUPr06WmRSmEe7g4aHR0twzCUKlUqSdIbb7yh6OhonT59Wjly5LAOc37z5k35+PjovffeU/bs2Qnf/0GYQjwPB6i4fy0Wi+7evavr169bR3K6f/++9f4D169f14QJE/Tee+/Jy8tL1atXV8mSJe32HuAY4valGzduyDAMvfvuu0qXLp0sFou1D3/Lli21aNEiVa5c2focbhJpHw//wG7fvl3p0qVToUKFVLFiReXMmVOtW7fWzZs39e6776pv375yd3fXzZs3tWXLFqVNm5YQ5aBGjRqladOmKVu2bGrWrJn1+1WiRAm1bt1aTk5O+uSTT5QlSxalSpVKMTExmjlzJt37kqGYmBidP39e/v7+OnnypHbv3q0xY8bIx8dHLi4uWrZsmVKnTq169erJx8dHPj4+9i4ZL1FgYKCyZ89u/dvujz/+0NKlSxUSEqL33ntP9evXV4YMGeTq6qps2bJpx44d1uH09+/frzt37qht27bxuvZxovMBuvnByjAMbdiwQVOmTLFO++abbzRjxgylSpVK7u7u+vvvv2UYhlxcXKz3k2nUqJFu376to0ePSpL69euXoGUBKUfcjR7j/o2KitKtW7fi3QDy/v37evPNN9W7d29t2bJFBw8elJubm+bNm6f333/fLnWnZA9fF/nFF19o1KhR2rp1q0JDQyVJHTp0kJOTk2JjY/X555/Lzc1N58+f16hRo7R9+3Z169bN+gMLx9KxY0e99dZbCgwM1Pr16+PdvLVixYqaOnWqxo4dq7Zt2+qbb77R7Nmz5e/vb8eK8TRiY2MTTEuXLp26du2qX375RR9//LGmTZumVq1aacWKFZo8ebLy5cun48eP26Fa2NvcuXPVqFEj/f333zKbzVq7dq0CAgLk5OSkDBkyaOzYserfv79OnTolSWratKk8PT1VokQJNW/eXL1791aNGjXiHecJUv+HlilY3b9/X5cuXdLMmTN18+ZNXb58WQcPHlSbNm2UOXNmZcyYUYsWLVL+/Pnl6+trPcN57949ubu7W4dgjWsuRspx5MgR7dy5U23btpWLi4sWLVqkXbt2aciQIcqZM6cyZ86sefPmqVu3bnrttdesB+FUqVJZ/5Ok7NmzS0rZowLZQ9xn3atXL/3zzz/q16+fChcubO3m9e677+ru3buaPHmy6tevLx8fHzk5OSk0NFTTpk1T7ty57Vg94vx31D5JcnNz09y5c9WkSRMtW7ZMhQsXVtWqVeXs7GwdtCBuwBckDw9v5x07dig8PFxvv/22vLy81LhxY/n7+yssLEze3t7Knz+/JClNmjRycXHhOrgUKn369MqePbsGDBigfv36KTg4WB06dNCnn34qFxcXbdu2TV26dFFUVJQCAgJUtGhR/fjjj1q5cqWioqLUtm1b6y1KaJFKiDAFK1dXVzVs2FA3b97U3LlzlSpVKs2ZM0e+vr6SHnQXadmypYYMGaJWrVqpcuXKunTpktasWSNvb29lyZLFzu8A9mCxWBQSEqIZM2Zo3759qlq1qvr06aNvv/1WqVKlUu7cufXBBx9oxowZev3111W3bl1ly5ZNUVFRunLlijJkyCAXF5d46yRIvXwnT57Url271KVLF5UvX966DSwWi1KnTq3atWurcuXKWr58ue7cuaMcOXKoWLFi1j71sK+oqCjrSYm9e/fq3r17KlKkiDw8PJQ6dWrNmzdPH374oYYPHy6TyaQqVarI2dmZExfJ0MOj9u3cuVO3b9/Wa6+9pqZNm6pRo0YqXLhwvD94r1y5okmTJunatWvclDeF+t///qdUqVJp6tSp6tu3r2JjY9WxY0e5uLjIMAxVqFBBP/30k9q3b6+hQ4cqICBAefLkUffu3eOFd44Xj8ZNe5HA8OHDtXjxYrm4uKhmzZrq06ePdd6BAwesZy9MJpMyZMigW7duacaMGXQNScEiIiK0fv16DRgwQPfv31fPnj3VrFkz641bpQfdP1esWKE333xTJUqUUFhYmFavXq3OnTurbdu2dn4H2LZtm9q1a6d169YpR44c1h9NzkI6rrt372rq1Knq3LlzvFFXt2zZosjISGXMmFEBAQEqV66cvLy8FBkZqQ8//FB3795Vr1699O677yY4kQHHFXetsiQtWrRIP//8s7788ku9+eabmjBhgg4cOKAaNWqoXbt21iHRp0yZoj///FMXL160dvVDyvLwMXz9+vWaPXu2Dhw4oIEDB6pu3brWLqNOTk7atWuX9V5SX375JfvLUyJeIoHmzZtrypQpqlWrljZs2KABAwZY5xUpUkRLly7VN998oxYtWqhZs2ZauHAhQSoFMwxDHh4eypQpk2JjY2U2m7VlyxZJD1o77927J0nq37+/vvzyS2XNmlVr165VSEiIAgICrEGK8zovj8ViSTDN29tbZrNZR44ckfSgdTDuHlKStGrVKu3cudO6PNvL/hYtWqSpU6fq22+/lST9/vvvOnLkiIYPH66pU6eqRIkS6tWrl1atWqWQkBC5ublp8eLF8vDw0Ndff63t27fb+R3gSe7cuWP93sUFqbhbStStW1dVq1ZV7ty5NXr0aJUvX15r167VlClTdOvWLUVHRytNmjR68803NWvWLP4wTqFMJpP1eF2tWjW1atVKuXLl0ogRI/T333/LyclJZrNZsbGxKl26tCZMmKAdO3bo33//tXPlyQctU0hUSEiIJk6cqPXr16ty5crq16+fdd6mTZv0zjvvMPIarI4fP66goCBdunRJEydOVIECBTRt2jRJ8bsgSVJoaKjc3Nys+w9dB16eh7ts7N27V0WLFpWTk5MuX76sdu3aKUeOHOrRo4e1e69hGPr33381bNgwFS9eXM2aNUtwXQ7sIyQkRLNmzdKKFStUunRpvfHGG5Kk9u3bW5fp3bu3fvvtN/Xs2VM1a9aUt7e37ty5o08++UQjRoywPgeOxzAM9ejRQyaTSSNGjJCzs7N2796tli1bSpK6d++u9u3bx2ux6tevn7Zv366aNWuqXbt2SpcuXYLjL1Kmh1uoNm3apJ9++kkRERH67rvvVKJECRmGYR2M6Nq1a8qcObOdK04+CFN4rJs3b2ry5Mlav369KlSooLZt22ratGn666+/NG/ePL322mv2LhEOJjIyUkuXLtX48ePjBSqLxaLDhw8re/bs8e5rQjeyl+fhINW7d28dP35ctWrVUps2bSQ9aH364osvVKNGDTVs2FDvvPOOjh8/rnnz5mnz5s2aO3eucubMac+3kOL99/sSFRWl77//Xnv37lVgYKB69+6t+vXrx+tiGxeo4u4TmCFDBr53yURQUJDSpk0rNzc3nTlzRnny5NGCBQs0btw45cqVS9OmTZOrq2u8QDVgwAAtW7ZMLVu2VNeuXTlRBauHv/cbNmzQtGnTFBYWpgEDBqh48eIJjguc6Hw6hCk8UXBwsKZNm6bFixfL1dVVzs7OmjhxonWUICBO3IE4IiJCy5cv1/jx41WwYEENGjRIf//9t/r3769BgwZZb/wM++jevbsOHjyoXr16KV++fMqaNat13vLlyzVq1CiFhYXJzc1NadKkUWxsLNdbOIC421ecP39e7dq1kyQNGjRIadKkUUxMjBYsWKACBQpo9uzZkhQvUPXt21cLFy7UwIED1aBBA5lMJsJUMjJ16lRNnDhREyZMUNmyZTV//nwNGTJE1apV06hRoyTFv6Zq2LBh+uijjzj5gQT+G6imT5+uGzduaMCAAdabeuPZMJofnihDhgzq1KmTqlSposuXL6tEiRLx/vgC4sT1zfbw8FC9evVkMpk0btw41alTR4ZhqGXLlgQpO1u8eLEOHDig0aNHq1ChQnJyclJkZKSuX7+udOnSqW7dusqXL5/OnDmjkydPKm/evHr77bf5zjuA/96+IjAwUAcOHNCCBQvk7e0tV1dXLVy4UAEBARo6dKhcXV2tgWrAgAFydXXV22+/zZnmZKhKlSratm2b+vfvr379+qlJkyaSpMGDB1vvDRd3/0dXV1cFBATYuWK8bP9tVXrUrRKk//udNplMqlq1qgzD0NixY3X9+vWXWe4rhZYpAEku7kAdFRWlkydP6siRI8qaNasqVqwoia4D9jR9+nQtXbpUs2fPlre3t/bu3ashQ4bo1q1bioqK0sCBA1WlShV7l4lEhIWFadKkSfFuXxE3AFBYWJimTJmiVatWqVSpUho2bJik+C1USL4uXbqk3r1769q1a+rfv7+1hWrw4MGqWbOmRowYYe8S4QCOHTumt95664nLPRy+AgMDrfd5xLPjrxkASe7hm/IWKlRITZs2JUjZwcPnyuL+32w269q1a5o4caK++OILtW7dWq+//rrat2+vAgUKaPDgwbp79669SsYTPHxz9LgbZD88r127dqpVq5Z2796t3r17SxJB6hWRI0cODR48WJkzZ1a/fv30119/qUmTJurTp49WrFgR7zYmSJlOnDihdu3aaevWrU9c1mQyWUd2jQtStK/Yhm5+AB4rqS9UJ0i9HDExMXJ2/r9DfNw2bNWqlc6cOaPdu3fr9ddf17fffqtGjRpZl7l8+bLu3bunNGnS2KVuPFnz5s1VvXp1rV69WuvWrZNhGOrbt6+k/wtUZrNZCxYskJOTU7zbWyB5iwtUvXv3Vr9+/TRgwAA1atRITk5OKlKkiL3Lg515eHjIMAzt37/fegLzcf57L0Guo7QN3fwAJOrhg+zBgwd19epVhYSEqFKlSsqQIcNTDbfLqGEvT1wf+Yc/88mTJ+vkyZNKly6d8ubNq2bNmkl6cP+auOvbpAfD1Q8cOFC3bt3S+PHj5ebmZrf3gafz8O0rqlSpYg1UkrR06VKdPn1aTZs2pfvOK+jSpUvq27evjh07pnHjxqlUqVL2Lgl2FtfrY9asWZo4caJmzpz5xEGDHv6tWLRokXLlyqVixYq9jHJfKZwiBpCouIPs4sWL1a5dO33//ff68ccf9eGHH2rWrFkKDAx87PMfPlBv27ZNFy5ceNElp1jR0dFq0qSJFi5caP3Me/TooRkzZujmzZs6dOiQhg4dqs8++0zXr1+Xu7u7NUjt27dPw4cP159//qmAgACCVDLh7e2tDh06qFq1atq4caP69Oljva5m9uzZatmyJUHqFZUjRw7169dPb7/9NvcDSuHu378f73HRokXl5eWlvXv3Snpwku1RHv59/uWXX9SnTx9dvXr1xRb7iqKbH4DH2r17t4YNG6YuXbronXfeUe7cuTVy5EiNHTtWMTExatu2rXU43oc9fKCeNWuWhg4dqhkzZnCT0Bfk7t27eu211zR06FClSpVKefPm1YULF/TDDz+oTJkyioiI0M6dO9W3b1/17dtXkydPliQtXLhQEydOlLe3t2bPnm29WS+Sh4wZM6pjx45ycXHR4sWLtWnTJjk7O2vChAn8kf2Ke/PNNzVu3LhHHn/x6nr4t3XNmjU6cOCAatWqpYIFC0qSChUqpLffflvTp09X48aNH3nN5MPrmD17toYOHapBgwbpgw8+eHlv5BVCmALwWMeOHVOePHn03nvvycfHR5J08eJFZcmSRVWrVpWLi0uCIVgfPlDPmTNH33//PfeweMHSpUungQMH6vvvv1e/fv3UqFEjZcyY0XodhYeHh6pVq6bUqVPrs88+0/jx49W5c2c1atRI6dOnV6FChazbF8kLt69IuQhSKUdUVJRSpUpl/W2NiYnRqVOntHXrVv3yyy+qX7++SpQooQ8++EBt2rTR4cOHNW/ePLVs2TJeV/v//j4PHTpUAwYM0IcffmiX9/UqIEwBsHr4IHvz5k1lzJhRZ8+eVWhoqPUP7U8//VRnzpzR5MmT5evrq7179yo2NlYlS5aMd/8K6cGBesiQIRowYIAaNmxot/f1qov7zL29vfXFF1/IbDZr9uzZypYtm27duhVvMImSJUuqatWq2rNnjyIiIqwhC8lb2rRpVbx4cRUvXtzepQBIYidOnNCKFStUv3595cmTR7Nnz9aiRYu0cuVKNW/eXNu3b9evv/6qTZs2afHixapZs6YMw9CxY8cSXLP8cI+R4cOH8/ucBLhmCoBV3EF2wYIF6tevnwIDA+Xn56fY2FidOHFCbdu21enTpzVp0iT5+/srLCxM8+fP165du6z9th/uOjBs2DAO1C9YbGxsvB/LjBkzKiAgQM2aNdPly5e1bt26eH3qU6VKJW9vbwUFBTEwCAA4MMMwZBiG3NzctH37dnXr1k0TJkzQiBEjVKtWLRmGIW9vb9WpU0fjx4/X+PHjZTab9fvvv+vs2bNasWKF1q5dm2C9q1ev1vfff6/vvvuO3+ckQMsUgHitSUFBQZo8ebIaN26sbNmyqXz58vrhhx/00UcfycvLS1OmTJGfn5+io6O1ceNG7d+/XzVq1IjXL/u3337TkCFDNHDgQA7UL9DD3StXr16t69evKzo6Wh988IHatm0rwzA0cuRIpU6dWtWrV5e3t7euX79u7aZJmAIAx3Xjxg299tprypYtm6ZOnar69etr0qRJatOmjdq3b5/gRFrGjBk1Y8YMHTp0SHv27NH06dO1ZcsWa++DuFuT+Pj46IcfflDVqlXt8r5eNYQpANYD8p9//qkzZ84oX758qlevnkwmk9544w39+OOP6ty5s3x8fHT16lVFRkZq165dmjJlijp27Gg9UMeFsoiICI0dO1Y1atSw59t6pRmGYQ1S3bp108GDBxUVFaXY2FhNnz5dHTt2VJMmTSRJ3333nVatWqUcOXLo1q1bOnr0qKZPn86ofQDgoCZMmKAVK1Zo2bJlcnNzU3h4uO7cuSN3d3dt3LhRtWvXVu7cueM9J2549EKFCqlQoULy9PTUd999p44dOypHjhzW5Rj+PGlxnykAkh60SHXs2FGBgYHKnTu35s+fL+n/bv66d+9e9evXT3fv3tXt27eVK1cuffDBB/r4448l/d9BHC/XmDFjtGTJEo0ePVrZsmWTk5OTRowYoQ0bNuizzz5TzZo1NWPGDM2bN0/58+dX69atVbBgwXg/rAAAx/Lnn3/K09NThQoVsoaoY8eOKSYmRgEBAXJyctLo0aOVN2/eBM+Njo6Wq6urgoKC9OGHH+qrr75S7dq17fAuUgbCFACrVatW6ZdfftE///yjadOm6Z133pFhGLJYLHJyclJoaKgiIiJ07949eXl5KWPGjJIIUvYSHR2tLl26KGPGjBo8eHC8eT179tTatWs1b948ZcuWTf369dPu3bu1YcMGpU6d2k4VAwAe5783ut+xY4e6d++uefPmKU+ePIqJidGJEyf09ddfy2w264cfflCePHkkSVu3blXBggXl7e0tSTpy5IgaNmyo0aNHq2bNmnZ5PykBf/0AKVBi51Bq1aql1q1by9/fX99995327t0rk8kkk8mk2NhYeXl5KVu2bMqTJ481SBmGQZCyo+vXrys8PNz6OG6wiQEDBihjxoyaPXu2PDw81KtXLy1ZsoQgBQAOzGQyxRs0yNnZWd7e3mrbtq3Onj0rZ2dn+fv7a8SIEbJYLOrRo4fWrVunxYsXq3379lq1apWkB0Opb9myRRUqVCBIvWC0TAEpzMNnvQ4cOKCzZ8/KZDIpS5YsKl26tCRp7dq1mj59uiIiItS/f38VL148wdky2F9MTIz69OmjvXv3atSoUSpUqJB1XmxsrJo1a6ZMmTJp3LhxdqwSAPAkhw4d0tmzZ1WvXj1J0pIlS3Tp0iV1795d27Zt0w8//KAbN25o5syZyp07t2JiYnTy5En16tVL58+fl4eHh1q1aqV27dpZ1xkUFGS9rQk9SF4cwhSQQi1dulSDBw9W5syZdfPmTaVKlUrly5e3dhdbv369pk2bprt376pPnz4qUaKEnSvGo5w8eVKNGjXSO++8o27dusnX11eSFBISos6dO6tAgQLq2bOnJBGGAcABxcTEaN26derdu7eaNm2qfPny6csvv1SfPn3UrFkzSQ+68I0dOzZeoJIe9Eb466+/rDdfj1ufs/P/jTHHydAXizAFpEB79+7VZ599prZt2+qDDz6Qm5ub9UDeuXNnde7cWdKDQDVp0iTdvHlTixcvVqZMmTggO6AtW7aoa9euypMnjypXriwfHx9t375du3bt0vz585UrVy57lwgAeIygoCAtW7ZM48ePl/RgFNYPP/wwXjBKLFA9jBaol4+h0YEU6NChQ8qaNavef/99axeAP/74Qzly5NC7775rXa5atWqKioqS2WzWa6+9Zqdq8STvvvuufvnlFw0fPly//vqrXF1d5ePjo9mzZxOkACAZ8PHxUc6cORUTEyOz2azjx49LenDNVNzofBUrVpT0YNj0Zs2aac6cOQlG8yNIvXyEKeAV96jm/UuXLkmSMmfOLElq27atTp8+rZ9++kn+/v7asWOHrl+/rnr16un9999/7LrgGAoVKqQpU6YoIiJCFotFadOmlYeHh73LAgA8QdwN2D09PTVs2DCdPXtWs2bNkslk0rfffitXV9d4gcpsNqtfv346cODAI4dGx8tFmAJecXHhZ+fOnSpWrJhcXV3l5+enJUuW6OLFixo1apROnTplDVKhoaHatm2bzGazIiIi4v1BTpBybO7u7nJ3d7d3GQCAJ3j45GRUVJTc3NxUrlw5SdK1a9dkNps1Y8YMSbIGKovFovPnz6t8+fKaP38+PUYcBG2BQApw9epVffnll5o8ebIkqXz58sqXL5/q1KmjvXv3auHChfL399f9+/e1ceNGrVu3ToULF6ZlAwCAFyAuSG3YsEFffPGFOnXqpOnTp+vOnTvKnDmzGjdurE8++UQLFy7UkCFDFBUVpTVr1qhZs2bauXOnNUgx9IH90TIFpADp06eXv7+/9u3bJ4vFomzZsqlJkyb65ZdfdOvWLV26dEmnTp3S8ePHNXHiRHXq1EnvvfeevcsGAOCVtX79enXv3l3ly5dXYGCgTpw4oV27dmnUqFHKkiWLGjduLJPJpClTpmjz5s26deuWWrVqpTJlyljXQY8R+2M0P+AVFzcS0LFjx9SkSRN99dVXatGihaQHZ8SWL1+uHTt2KHXq1MqZM6dq1aplnc+oQAAAJL3w8HCNHj1aGTJkULt27eTq6qoZM2ZYu+9NnDhRadOmVXBwsI4cOaKDBw/K399f1atXl8TvsyMhTAGvqDt37livn7FYLIqMjNSAAQP077//6vvvv7cOPiFJZ86ckZubm5ydna1dBzhQAwCQ9NavX685c+ZIkj755BNVqlRJkhQdHa1FixZp9uzZ8vHx0YQJE5Q2bdoEz+f32bGwJYBX0Lp16/TVV19pzZo1kh4Mlerh4aFKlSrpn3/+0cmTJyU9OCBLUp48eZQlSxZlypRJ0oM+2ByoAQBIel5eXjp69Kj27NmjGzduWKe7urqqUaNG+vjjj3Xz5k21b99e4eHhCZ7P77NjYWsAr6Br164pJCREX375pTp16qSlS5dKkmrWrKnq1atr1KhRCg0NTXBAjut7TR9sAACSzsMdwUqUKKEZM2YoY8aMWrhwofUEpyS5uLioUaNG+uijj3T+/Hnt3LnTHuXiGdDND0jmErv3U2hoqA4ePKgff/xRN2/elLe3t7p06aKLFy9q7dq1at26tbXvNQAASFoP/z7fvXtXZrNZqVKlss7ft2+fOnbsqLfeeku9evWSr6+vdd79+/d17tw5+fn5vfS68WwIU0Ay9vCB+vDhw7p586aCg4NVuXJleXh4yNXVVbdu3dKhQ4c0ffp0BQYGKmPGjDp06JCqVq2q8ePH2/kdAADw6nn493n16tVasGCBbt68qbRp0+qTTz5R8eLFlSFDBu3du1efffaZ8uXLp969ez/yJrxcI+XYCFPAK2DJkiX6/vvv5erqqjt37lgP1jVq1Ig30MSyZct0+PBhzZs3T126dNFnn31mx6oBAHi1rVy5Uj179lSDBg302muv6eTJkzp48KDKli2rzz//XD4+Ptq/f786d+6sXLly6dtvv5W/v7+9y8YzIEwBydzOnTv12WefqVu3bipdurT8/PzUt29fLV++XF27dlWrVq1kMpnk5ORkfc6VK1eUNWtWSYl3EwQAAM/m4VakkJAQtW3bVqVKlVLnzp3l5uYmSSpdurR8fX01YsQI6wnPvXv3qnnz5ho3bpyqVatmt/rx7GgzBJK5Q4cOKX/+/KpZs6a1b/XNmzeVOXNmVaxYUc7OzgnCUpYsWSQ9OOgTpAAAeD5btmxRSEiIzGazdaTcO3fu6PLly3r77betQapjx45ydXVVz549lTlzZgUFBenevXsqXry4tm3bRpBKhghTQDLyqIbko0ePKiIiwnp/qE8//VRHjx7Vjz/+qLx582r//v06ePBgvOfEBSj6YAMA8HzWr1+vzz//XD/99JNu3bpl/W11dXWVk5OTdXjzdu3a6fjx45oyZYry5cunw4cPa/z48dbh0R++zyOSD/6SApKJh7vjnTlzRqdPn5YkFShQQNHR0Tp37pzatm2r06dPa/LkyfL391doaKjmzJmjPXv2KCYmxp7lAwDwSqpWrZpq166tjRs36qefflJISIgkKXXq1MqSJYt+//13ffzxxzp58qSmTJkif39/xcTEaP/+/Tp16pSioqLirY8TnckLWwtIBh4OUitWrFCPHj00Z84c3b59W6VLl1ZgYKCaNGmis2fPatq0acqXL5/u37+vzZs369ChQ8qdO7ecnZ3t/C4AAHi1REdHS5IGDBigChUqaPPmzdZAlS5dOn399dfau3ev9uzZo549e8rX11fh4eFauXKlxo0bp9q1aytPnjx2fhd4HgxAASQjK1asUJ8+fdS+fXtVrlzZOuLPmjVr1KNHDxUvXlwdO3aUp6enduzYoUmTJqljx45q166dnSsHAODV8vCJzhMnTujChQsaNGiQDMNQ7dq11bZtW3l7e2vLli3q1q2b8ubNq3Tp0snZ2VkHDx5Uq1at1KFDhwTrQvJCmAKSicDAQH366aeqXbu22rVrJxcXF+t0V1dX/fvvv/rqq68UFRWlu3fvKnv27Kpdu7ZatWoliftUAADwvOJCz8PhZ/ny5fruu+/0wQcfKDIyUhcuXNCZM2fUtGlTa6A6duyYNm3apOPHj6tAgQLKmzevqlatKonf5+SOfj9AMnHv3j1FRkaqUKFCcnFxUUhIiAYOHKjDhw/r8uXL6tGjhxYuXKhbt24pKipK6dOntw65yoEaAIDnd/LkSfn7+1uD1L///qvRo0erWbNm6tq1q1KlSiVJCggI0MqVKyVJbdu21VtvvaV8+fIlaH3i9zn5I0wByYSnp6ciIiK0YMECrVmzRnv27JHJZFLTpk0VGRmp0aNHK3fu3KpSpUq85xmGwYEaAIDnNG3aNK1YsUKzZs2Sl5eXTCaT7ty5o7CwMBUtWlSpUqXS/fv35eLiomHDhqlTp06aNWuWzGaz2rRpI29v7wTr5Pc5+WMLAsmEj4+PJk6cqBMnTujatWuqWLGi1q5dq9atW6tmzZrKkiXLIw/K9MEGAOD51ahRQ0OHDlX69Ol18+ZNSQ9+m81ms44ePSrp/7V370E15n8cwN9JZ3VUqK2NLtg4odBFqGalFq3CqYw9bMUadtFK04wZR7mspRq3be0yo1VjyTA1U8lxqZCGZVhjW4URuXWxLoXpdFE5Pb8/TM/s2RNrj59ap/drxsx5Ps/3Od/P15lx+vheAkxMTMRDKdasWYO+ffsiPz8fP/zwg86pfWQYODNF9B7x9vZGbm4uJBKJuGfq+fPnKC0tBQD069evK9MjIiIyWA4ODgCA3377DcuXL8eqVaswZcoUBAYG4vjx4xg5ciQCAgIgkUgAADU1NTA3N4e9vb04c0WGh8UU0Xumd+/e4uuSkhJcuXIFmzdvRlRUFNzc3LouMSIiom7AxsYGtra2SE5OhqWlJaKjo7FgwQKkpqZCrVZDLpdDrVbj5s2bcHJywsaNG2Fubt7VadM7wtP8iN5TlZWVWLFiBWprazFnzhzx1D4er0pERPRuVVZWIi4uDn/++SeSk5NhamqKNWvWoKysDHZ2dpBKpbhy5Qqio6OxaNEiAPx+NlQspojeUxqNBlevXkVrays8PT0B8FQgIiKizlJRUYG4uDg8ePAAW7duxeDBg1FYWIi8vDxYW1vD3d0dYWFhAFhIGTIWU0QGgv9QExERda6/FlTfffcdfHx8dL6P+R+dho2fLJGBYCFFRETUuRwdHZGYmAh7e3vExcWhoKBA5/uYhZRh46dLRERERKQnR0dHrFu3DpaWlmhoaOjqdKiTcZkfEREREdFbUqvVPLWvG2IxRURERET0f8I9zN0Ll/kREREREf2fsJDqXlhMERERERER6YHFFBERERERkR5YTBEREREREemBxRQREREREZEeWEwRERERERHpgcUUERERERGRHlhMERGRloCAACiVyi7rX6lUIiAgQCvW0NCA+Ph4+Pr6wtnZGQkJCaiqqoKzszOys7M7PcfIyEhERkZ2er9ERPTf0rOrEyAios5RUVGB1NRUnD17Fo8ePYKJiQlkMhmmTp0KhUKBXr16dXWKr5SSkoKcnBxERUXBwcEBTk5O77zP8vJyHDt2DKGhobC3t3/n/f2TgIAAVFdX/2O7pKQkhIWFdUJGRETEYoqIqBsoKipCTEwMJBIJ5HI5ZDIZWltbcenSJWzevBnl5eVYv359V6cJAFi/fj0EQdCKnT9/HqNHj8bSpUvFmCAIKCkpQc+e7+arrLy8HNu3b8fYsWN1iqm0tLR30ufrxMXFoaGhQbw+ffo0Dh8+jJUrV6Jfv35i3MPDo9NzIyLqrlhMEREZuMrKSsTGxmLAgAHYs2cPbGxsxHvh4eG4d+8eioqKui7BvzExMdGJ1dbWYsiQIVoxIyMjfPDBB52VlhaJRNLpfU6aNEnruqamBocPH8akSZP+EzNnRETdEfdMEREZuNTUVDQ2NiIhIUGrkGo3cOBAzJs375XPP3v2DBs3bsT06dPh7u4ODw8PLFy4ENevX9dpm56ejuDgYIwePRpeXl4ICwuDSqUS79fX1yMhIQEBAQFwdXWFt7c35s+fj6tXr4pt/rpn6sKFC3B2dkZVVRWKiorg7OwsXr9qz9StW7cQExOD8ePHY9SoUQgMDERycrJ4v7q6Gt9++y0CAwMxatQojBs3DsuWLUNVVZXYJjs7GzExMQCAuXPniv1euHABQMd7pmpraxEXFwcfHx+MHDkSM2bMQE5Ojlab9pzT0tKQkZGBSZMmwdXVFTNnzkRJSckrP4M38eOPP8LFxQVPnjzRubd69WqMGTMGzc3NAF4uGVy0aBF+/fVXyOVyjBw5EkFBQSgoKNB5tq6uDgkJCfDz84OrqysmT56Mn3/+GW1tbW+VLxGRIeDMFBGRgTt16hQcHBz0Xv5VWVmJEydO4LPPPoO9vT1qamqQkZGBiIgIHDlyBB999BEAIDMzExs2bEBgYCDmzp2L5uZmlJWV4fLly5g+fToAYO3atcjPz0dERAScnJzw7NkzXLp0Cbdu3YKLi4tO305OTti0aROSkpJga2uL+fPnAwAsLS07LBquX7+O8PBw9OzZEwqFAnZ2dqioqEBhYSFiY2MBAKWlpSguLkZwcDBsbW1RXV2NAwcOYO7cuThy5AhMTU3h5eWFyMhIpKenY/Hixfj444/FfDry/PlzREZGoqKiAuHh4bC3t0deXh6USiXq6up0itXDhw+joaEBCoUCRkZGSE1NRXR0NE6cONHhzNybkMvl2LFjB44ePYqIiAgx3tLSgvz8fEyZMkVrJu/u3buIjY3F7NmzERoaiqysLMTExCA1NRW+vr4AgKamJkRERODhw4eYPXs2+vfvj+LiYnz//fd4/Pgx4uPj9cqViMhgCEREZLDUarUgk8mEJUuWvPEz/v7+wooVK8Tr5uZmQaPRaLWprKwUXF1dhe3bt4uxJUuWCMHBwa99b09PT2HdunWvbbNixQrB399fJ6evv/5aJweZTCZkZWWJsfDwcMHd3V2orq7WatvW1ia+bmpq0umzuLhYkMlkQk5Ojhg7duyYIJPJhPPnz+u0j4iIECIiIsTrX375RZDJZEJubq4Ya2lpERQKheDm5iao1WqtnMeOHSs8e/ZMbHvixAlBJpMJhYWFHf6ddCQ1NVWQyWRCZWWlGFMoFMKsWbO02hUUFOiMw9/fX5DJZEJ+fr4YU6vVgq+vrxASEiLGduzYIbi5uQl37tzRes8tW7YIw4cPF+7fv//G+RIRGSIu8yMiMmD19fUAgN69e+v9HhKJBD16vPy60Gg0ePr0KaRSKQYPHoxr166J7SwsLPDgwYPXLlezsLDA5cuX8fDhQ73zeZUnT57g4sWLmDlzJgYMGKB1z8jISHz911MLW1tb8fTpUzg6OsLCwkJrPP/G6dOnYW1tjWnTpokxExMTREZGorGxERcvXtRqHxQUhD59+ojXY8aMAfByFvBtyOVyXL58GRUVFWJMpVKhf//+GDt2rFZbGxsbTJ48Wbw2MzNDSEgIrl27hsePHwMA8vLy4OnpCQsLCzx58kT84+PjA41GozMuIqLuhsv8iIgMmJmZGQBonQL3b7W1tWHv3r3Yv38/qqqqoNFoxHt9+/YVX3/11Vc4d+4cZs2ahYEDB8LX1xfTpk2Dp6en2Gb58uVQKpWYOHEiXFxc4Ofnh5CQEDg4OOidX7v2QkQmk7223fPnz5GSkoLs7Gw8fPhQ6+RAtVqtV9/V1dUYOHCgWHS2a18WeP/+fa14//79ta7bC6u6ujq9+m8XFBSExMREHDp0CEuXLoVarcapU6fw5ZdfahWUwMu9cn+PDRo0SByPtbU17t27h7KyMnh7e3fYX0dLLYmIuhMWU0REBszMzAw2Nja4efOm3u+xc+dObNu2DTNnzkRMTAz69OmDHj16IDExUasQcXJyQl5eHoqKinDmzBkUFBRg//79+Oabb7Bs2TIAL3/YHzNmDI4fP46zZ88iLS0Nu3btwk8//QQ/P7+3Hu+bWL9+PbKzszFv3jy4ubnB3NwcRkZGiI2N1TmS/V0xNjbuMP62/ffp0wf+/v5QqVRYunQp8vLy0NLSghkzZuj1fm1tbfD19cXChQs7vN9efBERdVcspoiIDJy/vz8yMjJQXFwMd3f3f/18fn4+xo0bh8TERK14XV2d1u83AgCpVIqgoCAEBQWhpaUF0dHR2LlzJxYtWiQefmBjY4Pw8HCEh4ejtrYWoaGh2Llz51sXU+2zWzdu3PjH8YSEhECpVIqx5uZmnVmpv8/avI6dnR3KysrQ1tamNTt1+/ZtANBZdvguyeVyREVFoaSkBCqVCiNGjMDQoUN12t27dw+CIGiN8+7duwBejgcAHB0d0djYCB8fn07JnYjofcM9U0REBm7hwoWQSqVYtWoVampqdO5XVFRgz549r3ze2NhYZ8bk2LFjOvuenj59qnUtkUjg5OQEQRDQ2toKjUajU7BYWVnBxsYGLS0t/3ZYOiwtLeHl5YWsrCydZXV/zb+jWaH09HSt5YsAYGpqCuDNlv5NmDABjx8/xtGjR8XYixcvkJ6eDqlUCi8vr381lrcxYcIE9OvXD6mpqbh48eIrZ6UePXqE48ePi9f19fU4ePAghg8fDmtrawDA1KlTUVxcjDNnzug8X1dXhxcvXrybQRARvSc4M0VEZOAcHR2xZcsWxMbGIigoCHK5HDKZDC0tLSguLkZeXh7CwsJe+fzEiROxY8cOrFy5Eu7u7rhx4wZUKpXOPqcFCxbgww8/hIeHB6ysrHD79m3s27cPfn5+MDMzQ11dHfz8/BAYGIhhw4ZBKpXi3LlzKC0t1ZolehurVq3CnDlzEBoaCoVCAXt7e1RXV6OoqAi5ubnieHJzc2FmZoYhQ4bgjz/+wLlz57T2fwHA8OHDYWxsjF27dkGtVkMikWD8+PGwsrLS6VehUCAjIwNKpRJXr16FnZ0d8vPz8fvvvyMuLk7cu9YZTExMEBwcjH379sHY2BjBwcEdths0aBDi4+NRWloKKysrZGVloba2FklJSWKbBQsWoLCwEIsXL0ZoaChcXFzQ1NSEGzduID8/HydPnoSlpWVnDY2I6D+HxRQRUTfw6aef4tChQ0hLS8PJkydx4MABSCQSODs7Q6lU4vPPP3/ls4sXL0ZTUxNUKhWOHj2KESNGICUlBVu3btVqp1AooFKpsHv3bjQ2NsLW1haRkZGIiooC8PIUvTlz5uDs2bMoKCiAIAhwdHTE2rVr8cUXX/xfxjls2DBkZmZi27ZtOHDgAJqbmzFgwABMnTpVbBMfH48ePXpApVKhubkZHh4e2L17t86+IGtra6xbtw4pKSmIj4+HRqPB3r17OyymevXqhfT0dGzZsgU5OTmor6/H4MGDkZSU9NpC9V2Ry+XYt28fvL29O/xFzcDLYmr16tXYtGkT7ty5A3t7eyQnJ+OTTz4R25iamiI9PR0pKSnIy8vDwYMHYWZmhkGDBiE6Ohrm5uadNSQiov8kI6GzdtsSERFRp7h+/Trkcjk2btyIkJAQnfsBAQEYOnQoUlJSOj85IiIDwj1TREREBiYzMxNSqRRTpkzp6lSIiAwal/kREREZiMLCQpSXlyMzMxPh4eGQSqVdnRIRkUFjMUVERGQgNmzYgJqaGkyYMAHR0dFdnQ4RkcHjnikiIiIiIiI9cM8UERERERGRHlhMERERERER6YHFFBERERERkR5YTBEREREREemBxRQREREREZEeWEwRERERERHpgcUUERERERGRHlhMERERERER6eF/1BNpY8OjkNAAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_percentages(classification_counts, ids_count)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rwPLjqW2Ajzh"
+   },
+   "source": [
+    "## Preprocess dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sample the data with **at least** a sample_size for each column in classification_columns  \n",
+    "Including a sample with rows where all classification_columns are 0   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Balance dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def balance_dataset(df: DataFrame, classification_columns: List, sample_size):\n",
+    "\n",
+    "    sampled_dfs = []\n",
+    "\n",
+    "    for col in classification_columns:\n",
+    "        temp_df = df[df[col] == 1].sample(sample_size)\n",
+    "        sampled_dfs.append(temp_df)\n",
+    "\n",
+    "    all_zeroes_df = df[(df[classification_columns] == 0).all(axis=1)].sample(sample_size)\n",
+    "    sampled_dfs.append(all_zeroes_df)\n",
+    "\n",
+    "    balanced_df = bpd.concat(sampled_dfs) # could create duplicates, dropping for simplicity\n",
+    "    balanced_df.drop_duplicates()\n",
+    "    \n",
+    "    return balanced_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SAMPLE_SIZE = 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "balanced_data = balance_dataset(df, classification_columns, sample_size = SAMPLE_SIZE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def plot_distribution(classification_counts: DataFrame):\n",
+    "\n",
+    "    plt.figure(figsize=(10, 5))\n",
+    "    plt.bar(classification_counts.index, classification_counts.values)\n",
+    "    plt.title('Distribution of Classifications')\n",
+    "    plt.xlabel('Classification Type')\n",
+    "    plt.ylabel('Number of Occurrences')\n",
+    "    plt.xticks(rotation=45)\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "balanced_data_counts = balanced_data[classification_columns].sum()\n",
+    "balanced_data_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total: 700\n"
+     ]
+    }
+   ],
+   "source": [
+    "total = balanced_data[\"id\"].count()\n",
+    "print(f\"Total: {total}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1wAAAIiCAYAAADcusnBAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACK4ElEQVR4nOzdd3gU1dvG8Xs3DQIkEEoQQg0kIE0UDEiTXgVFEaQogvSuKKFXadKkS5UqRYogkSIdpEjvNZSAEgwljZC67x+82R8xILBk2ZTv57q8ZGfOzj47M7ube+bMGYPJZDIJAAAAAJDkjLYuAAAAAABSKwIXAAAAAFgJgQsAAAAArITABQAAAABWQuACAAAAACshcAEAAACAlRC4AAAAAMBKCFwAAAAAYCUELgAAAACwEgIXACQTU6ZMkbe39yt5rVatWqlVq1bmxwcOHJC3t7c2btz4Sl7f19dX1apVeyWvZanw8HD1799fFSpUkLe3t7799tskWe7q1avl7e2tGzduJMnyXtSNGzfk7e2t1atXJ5i+a9cuNWrUSCVKlJC3t7dCQkJstp3i98cDBw688tcGgKRmb+sCACA1Wr16tfr27Wt+7OjoKFdXV3l7e6tKlSpq3LixMmbM+NKvExgYqBUrVqhGjRoqWrToSy8vKSXn2p7HDz/8oDVr1qhz587KkyePPD09/7N9bGys1q5dq7Vr1+r8+fN68OCBcuTIIR8fHzVv3lwlSpR4RZW/uHv37qlnz54qXLiwBg0aJEdHR6VPn97qr7tkyRKlT59ejRs3tvprAYCtELgAwIq6d+8uDw8PxcTEKCgoSAcPHtTIkSP1448/avr06SpSpIi5badOndS+ffsXWv7t27c1depU5c6d+4VCzdy5c1/odSzxX7UNHz5cJpPJ6jW8jP3796tUqVLq2rXrM9s+fPhQXbt21e7du1W2bFl16NBBrq6uunnzpn777TetWbNGO3bsUM6cOV9B5f8td+7cOnHihOzt//cnwMmTJxUeHq4ePXronXfeMU+39nb66aeflCVLlkSBq2zZsjpx4oQcHBys9toA8KoQuADAiipXrpzgzEaHDh20b98+dezYUZ07d5afn5/SpUsnSbK3t0/wR7A1REREKH369HJ0dLTq6zxLSvhD+s6dOypUqNBztR07dqx2796tvn37qnXr1gnmde3aVT/++GPSF2ghg8EgJyenBNPu3r0rScqUKVOC6bbaTkajMVGNAJBScQ0XALxi5cuXV+fOnXXz5k2tW7fOPP1J13Dt3btXn3zyicqUKaPSpUurdu3amjBhgqRH17l89NFHkqS+ffvK29s7wbU5rVq1UoMGDXTq1Cm1aNFCpUqVMj/339dwxYuLi9OECRNUoUIFvfHGG+rYsaP+/vvvBG2qVasmX1/fRM99fJnPqu1J1wY9ePBAo0ePVpUqVVS8eHHVrl1bc+fOTXSGxdvbW8OGDdPvv/+uBg0aqHjx4qpfv7527dr1X6vd7M6dO+rXr5/eeecdlShRQg0bNtSaNWvM8+OvH7px44Z27Nhhrv1p11zdunVLy5cvV4UKFRKFLUmys7NT27Zt//Ps1u+//6727durYsWKKl68uGrUqKFp06YpNjY2QburV6+qW7duqlChgkqUKKHKlSurV69eCg0NNbf5r31GSnwNV6tWrdSnTx9J0kcffSRvb2/z9n3SdoqLi9OCBQv03nvvqUSJEipXrpzatm2rkydPmtusWrVKn376qcqXL6/ixYurXr16Wrp0aYLlVKtWTRcvXtTBgwfN6/jx/edJ13D99ttvaty4sUqWLCkfHx/17t1bgYGBCdr4+vqqdOnSCgwMVOfOnVW6dGmVK1dOY8aMSbQ+N2zYoMaNG6t06dJ688039d5772nBggVP3U4AYAnOcAGADTRq1EgTJkzQnj179PHHHz+xzcWLF9WhQwd5e3ure/fucnR01LVr13TkyBFJkqenp7p3767JkyeradOmeuuttyRJb775pnkZ9+/fV7t27VS/fn01bNhQWbNm/c+6ZsyYIYPBoHbt2unOnTtasGCBWrdurV9++cV8Ju55PE9tjzOZTOrUqZM5qBUtWlS7d+/W2LFjFRgYqH79+iVof/jwYW3evFnNmzdXhgwZtGjRInXv3l3bt29XlixZnlrXw4cP1apVK12/fl0tWrSQh4eHNm7cKF9fX4WEhOizzz6Tp6enxo4dq1GjRilnzpz6/PPPJUlubm5PXOauXbsUExOjhg0bPvf6+bc1a9bI2dlZn3/+uZydnbV//35NnjxZYWFh5jAUFRWltm3bKioqSi1btlS2bNkUGBioHTt2KCQkRJkyZXrmPvMkHTt2VIECBbR8+XJzF9i8efM+tX3//v21evVqVa5cWR999JFiY2N16NAhHT9+3Hw296efflLhwoVVrVo12dvba/v27Ro6dKhMJpNatGghSerXr5+GDx8uZ2dndezYUZKULVu2p75u/HWRJUqU0Jdffqk7d+5o4cKFOnLkiNauXSsXFxdz29jYWLVt21YlS5bUN998o3379mnevHnKkyePmjdvLulRMP3yyy9Vvnx59e7dW5Lk7++vI0eO6LPPPnuezQYAz8cEAEhyq1atMnl5eZlOnDjx1DZvvfWW6f333zc/njx5ssnLy8v8eP78+SYvLy/TnTt3nrqMEydOmLy8vEyrVq1KNK9ly5YmLy8v008//fTEeS1btjQ/3r9/v8nLy8tUqVIlU2hoqHm6n5+fycvLy7RgwQLztKpVq5r69OnzzGX+V219+vQxVa1a1fx4y5YtJi8vL9P06dMTtOvWrZvJ29vbdO3aNfM0Ly8vU7FixRJMO3v2rMnLy8u0aNGiRK/1uB9//NHk5eVl+uWXX8zToqKiTE2bNjW98cYbCd571apVTe3bt//P5ZlMJtPIkSNNXl5epjNnzjyzrcn0v30jICDAPC0iIiJRu4EDB5pKlSplioyMNJlMJtOZM2dMXl5ept9+++2py36efSYgICDRdnna/vrv7bRv3z6Tl5eXafjw4YmWGxcX95/vp02bNqbq1asnmFa/fv0E+0y8+P1x//79JpPp0TYqX768qUGDBqaHDx+a223fvt3k5eVl+v777xPU7OXlZZo6dWqCZb7//vumDz74wPx4xIgRpjfffNMUExOT6PUBICnRpRAAbMTZ2Vnh4eFPnR9/xH7r1q2Ki4uz6DUcHR1faAS4999/P8HoiXXq1FH27Nm1c+dOi17/ee3atUt2dnaJujm2adNGJpMpUXfBd955J8FZmCJFiihjxowKCAh45utkz55dDRo0ME9zcHBQq1at9ODBA/35558vXHtYWJgkKUOGDC/83HiPnz0MCwvT3bt3VaZMGUVERMjf31+SzNtlz549ioiIeOJykmKf+S+bN2+WwWB44kAiBoPB/O/H309oaKju3r2rt99+WwEBAQm6Pz6vU6dO6c6dO/rkk08SXNv17rvvqmDBgtqxY0ei53zyyScJHr/11lsJuoW6uLgoIiJCe/fufeF6AOBF0KUQAGzkwYMH/9nFr169elq5cqUGDBig8ePHq3z58qpZs6bq1Kkjo/H5jpe5u7u/0AAZ+fLlS/DYYDAoX758unnz5nMvwxI3b95Ujhw5Eg2VHz8U+79f/7XXXku0DFdXV4WEhDzzdfLly5do/cW/zl9//fXCtcfX/F/h+VkuXryoSZMmaf/+/eYAFy8+oOTJk0eff/655s+fr/Xr16tMmTKqVq2aGjZsaB7sIin2mf9y/fp15ciRQ5kzZ/7PdocPH9aUKVN07NixROEwNDQ00eAczxK/XQoUKJBoXsGCBXX48OEE05ycnBJ1AXV1dVVwcLD5cfPmzfXbb7+pXbt2cnd3V4UKFVS3bl1Vrlz5hWoDgGchcAGADdy6dUuhoaH/ea1MunTptGTJEh04cEA7duzQ7t275efnp+XLl2vevHmys7N75uu8yHVXLys2Nva5akoKT3sdkw2Gmi9YsKAk6fz58xbdbywkJEQtW7ZUxowZ1b17d+XNm1dOTk46ffq0xo0bl+BMla+vrz744ANt3bpVe/fu1YgRI/TDDz9oxYoVypkzZ5LsMy/r+vXrat26tQoWLChfX1+99tprcnBw0M6dO/Xjjz9a5czbvz3P+8yaNavWrl2rPXv2aNeuXdq1a5dWr16t999/X2PGjLF6jQDSDroUAoAN/PLLL5KkihUr/mc7o9Go8uXLq2/fvvLz81OvXr20f/9+8+htj3fjSgrXrl1L8NhkMunatWvKnTu3edrTziT9++zQi9SWO3du3b59O9HZnfjudI+//svInTu3rl27luiP/vjXyZUr1wsvs3LlyrKzs9P69estqungwYO6f/++Ro8erc8++0xVq1bVO++8I1dX1ye29/b2VufOnbVkyRItWbJEgYGB+umnn8zzn7XPvIy8efPq9u3bun///lPbbNu2TVFRUZoxY4aaNWumKlWq6J133nli+H/efSR+u1y5ciXRvCtXrli03aRHXW6rVaumIUOG6Pfff1fTpk21du3aRJ8DAHgZBC4AeMX27dun6dOny8PD4z9HtnvSH7XxZ1CioqIkSenTp5ekZ3ale15r165NEHo2btyof/75J0E3qzx58uj48ePmGiRp+/btiYaPf5HaKleurNjYWC1ZsiTB9B9//FEGgyHJunlVrlxZ//zzj/z8/MzTYmJitGjRIjk7O6ts2bIvvMzXXntNTZo00Z49e7Ro0aJE8+Pi4jRv3jzdunXric+P7+r3+Nm5qKioRMOoh4WFKSYmJsE0Ly8vGY1G87Z4nn3mZdSqVUsmk0lTp05NNC++/vizS4+/n9DQUK1atSrRc9KnT/9c+0fx4sWVNWtWLVu2LMH72Llzpy5fvqx33333Rd+K7t27l+Cx0Wg035YhKdYVAMSjSyEAWNGuXbvk7++v2NhYBQUF6cCBA9q7d69y5cqlGTNm/OfNXadNm6ZDhw6pSpUqyp07t+7cuaOlS5cqZ86c5mHW8+bNKxcXFy1btkwZMmSQs7OzSpYsqTx58lhUr6urq5o3b67GjRubh4XPly9fgqHrmzRpok2bNumLL75Q3bp1df36da1fvz5R98gXqa1atWry8fHRxIkTdfPmTXl7e2vv3r3aunWrPvvss//sevkimjZtquXLl8vX11enT59W7ty5tWnTJh05ckT9+vVLdA3Z8/L19VVAQIBGjBihzZs3q2rVqnJxcdHff/+tjRs3yt/fX/Xr13/ic0uXLi1XV1f5+vqqVatWMhgM+uWXXxJ1j9y/f7+GDRumOnXqKH/+/IqNjdUvv/wiOzs71a5dW9Lz7TMvo1y5cmrUqJEWLVqka9euqVKlSoqLi9Phw4fl4+Ojli1bqkKFCnJwcFDHjh3VrFkzhYeHa+XKlcqaNav++eefBMsrVqyYfvrpJ02fPl358uWTm5ubypcvn+h1HRwc1Lt3b/Xt21ctW7ZU/fr1zcPC586d+4n3P3uWAQMGKDg4WOXKlZO7u7v++usvLV68WEWLFjVf0wcASYHABQBWNHnyZEmP/mDMnDmzvLy81K9fPzVu3PiZf9xXq1ZNN2/e1KpVq3Tv3j1lyZJFb7/9trp162YedMDBwUGjR4/WhAkTNGTIEMXExGjUqFEWB66OHTvq/PnzmjVrlsLDw1W+fHkNHjzYfLZKkipVqiRfX1/Nnz9fI0eOVPHixTVz5sxE1728SG1Go1EzZszQ5MmT5efnp9WrVyt37tz65ptv1KZNG4vey5OkS5dOixYt0rhx47RmzRqFhYWpQIECGjVq1AuN5vhv6dOn1+zZs7V69WqtXbtW06dP18OHD5UjRw75+Pho3Lhxcnd3f+Jzs2TJYl5/kyZNkouLixo2bKjy5curbdu25nbe3t6qWLGitm/frsDAQKVPn17e3t6aPXu23njjDUnPt8+8rFGjRsnb21s///yzxo4dq0yZMql48eIqXbq0pEfXtE2ePFmTJk3SmDFjlC1bNn3yySdyc3NLdD+1Ll266K+//tKcOXMUHh6ut99++4mBS5IaN26sdOnSafbs2Ro3bpycnZ1Vo0YNff311wnuwfW8GjZsqBUrVmjp0qUKCQlR9uzZVbduXXXr1i1JBhgBgHgGky2uMAYAAACANIBDOAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVcOPjF2QymRQXx63LkorRaGB9pnJs47SB7Zz6sY1TP7Zx2sB2TjpGo0EGg+GZ7QhcLyguzqS7d8NtXUaqYG9vVJYsGRQS8kAxMXG2LgdWwDZOG9jOqR/bOPVjG6cNbOek5eaWQXZ2zw5cdCkEAAAAACshcAEAAACAlRC4AAAAAMBKCFwAAAAAYCUELgAAAACwEgIXAAAAAFgJgQsAAAAArITABQAAAABWQuACAAAAACshcAEAAACAlRC4AAAAAMBKCFwAAAAAYCUELgAAAACwEgIXAAAAAFgJgQsAAAAArMTe1gXAckajQUajwdZlWMzOzpjg/ylRXJxJcXEmW5cBAACAZIrAlUIZjQZlzuycosNKPBeX9LYuwWKxsXG6f/8BoQsAAABPROBKoYxGg+zsjBq35LBuBIbaupw0ycM9k3q3eEtGo4HABQAAgCcicKVwNwJDdflmsK3LAAAAAPAEKb8/GgAAAAAkUwQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWEmyClyrV6+Wt7d3ov/GjRuXoN3KlStVu3ZtlShRQg0bNtT27dsTLSs0NFT9+vXT22+/rdKlS6t79+66ffv2q3orAAAAACB7WxfwJHPmzFGmTJnMj93d3c3/3rBhgwYOHKiOHTuqXLly8vPzU9euXbVkyRK98cYb5nY9e/bUpUuXNGTIEDk5OWnSpElq166dVq1aJXv7ZPm2AQAAAKQyyTJ5FCtWTG5ubk+cN3nyZNWvX189e/aUJJUrV04XLlzQtGnTNHv2bEnS0aNHtWfPHs2dO1cVK1aUJBUoUED16tXT5s2bVa9evVfyPgAAAACkbcmqS+GzBAQE6OrVq6pbt26C6fXq1dO+ffsUFRUlSdq1a5dcXFxUoUIFc5uCBQuqaNGi2rVr1yutGQAAAEDalSzPcDVo0ED37t1Trly59PHHH+uLL76QnZ2d/P39JT06W/U4T09PRUdHKyAgQJ6envL391eBAgVkMBgStCtYsKB5GS/D3t72OdXOzvY14BG2xdPFrxvWUerGdk792MapH9s4bWA720ayClzZs2dXt27dVKpUKRkMBm3btk2TJk1SYGCgBg0apODgYEmSi4tLgufFP46fHxISkuAasHiurq46derUS9VoNBqUJUuGl1oGUhcXl/S2LiHZYx2lDWzn1I9tnPqxjdMGtvOrlawCV6VKlVSpUiXz44oVK8rJyUkLFixQx44dbVjZ/8TFmRQS8sDWZcjOzsiHJZkICYlQbGycrctIluL3U9ZR6sZ2Tv3Yxqkf2zhtYDsnLReX9M91tjBZBa4nqVu3rubNm6ezZ8/K1dVV0qMh37Nnz25uExISIknm+S4uLrp161aiZQUHB5vbvIyYGHZQ/E9sbBz7xDOwjtIGtnPqxzZO/djGaQPb+dVKUR04CxYsKEmJrsPy9/eXg4OD8uTJY2535coVmUymBO2uXLliXgYAAAAAWFuyD1x+fn6ys7PT66+/rjx58ih//vzauHFjojbly5eXo6OjJKly5coKDg7Wvn37zG2uXLmiM2fOqHLlyq+0fgAAAABpV7LqUti2bVv5+PjI29tbkrR161atWLFCn376qbkLYbdu3dS7d2/lzZtXPj4+8vPz04kTJ7R48WLzckqXLq2KFSuqX79+6tOnj5ycnDRx4kR5e3urVq1aNnlvAAAAANKeZBW4ChQooFWrVunWrVuKi4tT/vz51a9fP7Vq1crcpkGDBoqIiNDs2bM1a9YsFShQQFOnTlXp0qUTLGvSpEkaNWqUBg0apJiYGFWsWFEDBgyQvX2yessAAAAAUjGD6d8XOuE/xcbG6e7dcFuXIXt7o7JkyaCeE3bo8s1gW5eTJnnmdtWkL9/VvXvhXHj6FPH7KesodWM7p35s49SPbZw2sJ2TlptbhucapTDZX8MFAAAAACkVgQsAAAAArITABQAAAABWQuACAAAAACshcAEAAACAlRC4AAAAAMBKCFwAAAAAYCUELgAAAACwEgIXAAAAAFgJgQsAAAAArITABQAAAABWQuACAAAAACshcAEAAACAlRC4AAAAAMBKCFwAAAAAYCUELgAAAACwEgIXAAAAAFgJgQsAAAAArMTe1gUAQFpnNBpkNBpsXYbF7OyMCf6fEsXFmRQXZ7J1GQCAVIjABQA2ZDQalDmzc4oOK/FcXNLbugSLxcbG6f79B4QuAECSI3ABgA0ZjQbZ2Rk1bslh3QgMtXU5aZKHeyb1bvGWjEYDgQsAkOQIXACQDNwIDNXlm8G2LgMAACSxlN+HBQAAAACSKQIXAAAAAFgJgQsAAAAArITABQAAAABWkqSDZgQEBCgqKkqenp5JuVgAAIBkLyXfUy813E9P4p56SJ4sClwLFy7U0aNHNXHiRPO0vn37au3atZKkokWLavbs2cqaNWuSFAkAAJCcpZZ76qXk++lJ3FMPyZNFgWvlypXy8fExP969e7fWrFmjpk2bysvLS99//72mTp2qwYMHJ1mhAAAAyRX31LM97qmH5MqiwPXXX38l6Db422+/ycPDQ0OHDpUkBQUF6ZdffkmaCgEAAFII7qkH4N8sOu9tMiU8arB3715VrlzZ/Dh37twKCgp6ucoAAAAAIIWzKHDlz59fv//+u6RH3Qlv376dIHDdunVLLi4uSVMhAAAAAKRQFnUpbNu2rb766iuVLVtWERER8vT0VMWKFc3zDxw4oCJFiiRZkQAAAACQElkUuOrXr6/MmTNr586dcnFxUfPmzWVv/2hR9+/fl6urqxo1apSkhQIAAABASmPxfbgqVKigChUqJJqeOXNmTZ069aWKAgAAAIDU4KVufBwYGKg///xTd+7cUe3atZUzZ07FxsYqNDRUmTJlkp2dXVLVCQAAAAApjkWBy2QyafTo0VqyZIliYmJkMBjk5eWlnDlz6sGDB6pWrZq6d++u1q1bJ3G5AAAAAJByWDRK4Zw5c7Rw4UK1adNG8+fPTzBMfKZMmVSrVi1t3rw5yYoEAAAAgJTIosC1cuVKvf/++/ryyy+fOBqht7e3rl69+rK1AQAAAECKZlHg+vvvv1W6dOmnzk+fPr3CwsIsLgoAAAAAUgOLAlfWrFn1999/P3X+6dOn9dprr1lcFAAAAACkBhYFrpo1a2rZsmUKCAgwTzMYDJKkPXv2aM2aNapTp07SVAgAAAAAKZRFoxR2795dBw4cUKNGjVSmTBkZDAbNnj1b33//vY4dO6aiRYuqY8eOSV0rAAAAAKQoFp3hypQpk1asWKEvvvhCgYGBcnJy0p9//qnQ0FB16dJFS5cuVfr06ZO6VgAAAABIUSy+8XG6dOnUuXNnde7cOSnrAQAAAIBUw6IzXDExMf85CmFYWJhiYmIsLgoAAAAAUgOLAteIESPUrFmzp87/5JNPNHr0aIuLAgAAAIDUwKLAtXv3btWuXfup82vXrq1du3ZZXBQAAAAApAYWBa7bt2/L3d39qfNz5MihwMBAi4sCAAAAgNTAosCVOXNmXbly5anzL1++rIwZM1pcFAAAAACkBhYFrkqVKmnZsmU6c+ZMonmnT5/WihUrVLly5ZcuDgAAAABSMouGhe/Ro4d2796tJk2aqFq1aipUqJAk6eLFi9q+fbvc3NzUo0ePJC0UAAAAAFIai85wubu7a9WqVWrQoIH27dunGTNmaMaMGdq/f7/ee+89/fzzz8qZM+dLFRYeHq7KlSvL29tbJ0+eTDBv5cqVql27tkqUKKGGDRtq+/btiZ4fGhqqfv366e2331bp0qXVvXt33b59+6VqAgAAAIAXYfGNj3PkyKExY8bIZDLp7t27kiQ3NzcZDIYkKWz69OmKjY1NNH3Dhg0aOHCgOnbsqHLlysnPz09du3bVkiVL9MYbb5jb9ezZU5cuXdKQIUPk5OSkSZMmqV27dlq1apXs7S1+2wAAAADw3Cw6w/U4g8GgrFmzKmvWrEkWti5fvqylS5eqW7duieZNnjxZ9evXV8+ePVWuXDkNGzZMJUqU0LRp08xtjh49qj179ujbb79VvXr1VL16dX3//fc6f/68Nm/enCQ1AgAAAMCzWHyqJzg4WL/++qtu3Lih4OBgmUymBPMNBoNGjhxp0bLjb6xcoECBBNMDAgJ09epVff311wmm16tXT2PHjlVUVJQcHR21a9cuubi4qEKFCuY2BQsWVNGiRbVr1y7Vq1fPoroAAAAA4EVYFLh2796t7t27KyIiQhkzZpSLi0uiNpae7dq4caMuXLigKVOm6PTp0wnm+fv7S1KiIObp6ano6GgFBATI09NT/v7+KlCgQKIaChYsaF7Gy7C3f+kTgy/Nzs72NeARtsXTxa8b1tHTsW6SD7bF0/FZfjbWTfLBtng6Psu2YVHgGjNmjLJnz64pU6bI29s7yYqJiIjQ6NGj1atXryfexys4OFiSEgW8+Mfx80NCQpQpU6ZEz3d1ddWpU6deqkaj0aAsWTK81DKQuri4pLd1Ccke6wgpAfvps7GOkBKwnz4b6+jVsihwXbt2Td98802Shi1JmjFjhrJmzaoPP/wwSZeblOLiTAoJeWDrMmRnZ+TDkkyEhEQoNjbO1mUkS/H7Kevo6fgsJx/sp0/HZ/nZ+CwnH+ynT8dnOWm5uKR/rrOFFgWu/PnzKzw83JKnPtXNmzc1b948TZs2TaGhoZKkBw8emP8fHh4uV1dXSY+GfM+ePbv5uSEhIZJknu/i4qJbt24leo3g4GBzm5cRE8MOiv+JjY1jn3gG1hFSAvbTZ2MdISVgP3021tGrZfGNj4cNG6YGDRrIw8MjSQq5ceOGoqOj1b59+0TzPv30U5UqVUrjx4+X9OharoIFC5rn+/v7y8HBQXny5JH06Fqtffv2yWQyJbiO68qVK/Ly8kqSegEAAADgWSwKXPv375ebm5vq1aund955R6+99prs7OwStRswYMBzL7No0aJauHBhgmlnz57VqFGjNHToUJUoUUJ58uRR/vz5tXHjRtWoUcPczs/PT+XLl5ejo6MkqXLlypo+fbr27dund955R9KjsHXmzBl98cUXlrxlAAAAAHhhFgWuxYsXm/+9Y8eOJ7YxGAwvFLhcXFzk4+PzxHnFihVTsWLFJEndunVT7969lTdvXvn4+MjPz08nTpxIUFPp0qVVsWJF9evXT3369JGTk5MmTpwob29v1apV67lrAgAAAICXYVHgOnfuXFLX8dwaNGigiIgIzZ49W7NmzVKBAgU0depUlS5dOkG7SZMmadSoURo0aJBiYmJUsWJFDRgwQPb2Ft96DAAAAABeSLJOHz4+Pjp//nyi6U2aNFGTJk3+87mZMmXSyJEjLb75MgAAAAC8rJcKXMeOHdOBAwd0584dNW/eXPnz51dERIT8/f2VP39+ZcjA/aoAAAAApF0WBa6oqCh9+eWX2rp1q3kkwKpVqyp//vwyGo1q06aNWrdurU6dOiV1vQAAAACQYjz7Tl1P8P3332vHjh0aMmSINm7cKJPJZJ7n5OSkOnXqaOvWrUlWJAAAAACkRBYFrg0bNqhZs2Zq2rTpE28k7OnpqYCAgJcuDgAAAABSMosC1507d+Tt7f3U+XZ2dnr48KHFRQEAAABAamBR4Hrttdfk7+//1PlHjhxR3rx5LS4KAAAAAFIDiwJXgwYNtGzZMh09etQ8zWAwSJJWrFih3377Te+//36SFAgAAAAAKZVFoxR27NhRx48fV8uWLVWwYEEZDAaNGjVKwcHBunXrlqpUqaLWrVsncakAAAAAkLJYFLgcHR01Z84crVu3Tps2bVJcXJyioqLk7e2tnj17qlGjRuYzXgAAAACQVr1w4Hr48KEmTpwoHx8fNWrUSI0aNbJGXQAAAACQ4r3wNVzp0qXT8uXLdefOHWvUAwAAAACphkWDZhQrVkwXLlxI6loAAAAAIFWxKHD169dPfn5+WrlypWJiYpK6JgAAAABIFSwaNMPX11cGg0GDBg3SiBEj5O7uLicnpwRtDAaD1q1blyRFAgAAAEBKZFHgypw5szJnzqwCBQokdT0AAAAAkGpYFLgWLVqU1HUAAAAAQKrzwtdwRUREyMfHR3PnzrVGPQAAAACQarxw4EqfPr3s7OyULl06a9QDAAAAAKmGRaMU1qpVS5s2bZLJZErqegAAAAAg1bDoGq769etr6NCh+vTTT9WkSRPlzp37iWe8ihUr9tIFAgAAAEBKZVHgatWqlfnfhw4dSjTfZDLJYDDo7NmzllcGAAAAACmcRYFr1KhRSV0HAAAAAKQ6FgWuDz74IKnrAAAAAIBUx6JBMwAAAAAAz2bRGa6+ffs+s43BYNDIkSMtWTwAAAAApAoWBa4DBw4kmhYXF6d//vlHsbGxcnNzU/r06V+6OAAAAABIySwKXNu2bXvi9OjoaC1fvlwLFizQvHnzXqowAAAAAEjpkvQaLgcHB7Vs2VIVKlTQ8OHDk3LRAAAAAJDiWGXQjCJFiujPP/+0xqIBAAAAIMWwSuD6448/uIYLAAAAQJpn0TVcU6dOfeL00NBQ/fnnnzpz5ozat2//UoUBAAAAQEqXpIHL1dVVefLk0dChQ/Xxxx+/VGEAAAAAkNJZFLjOnTuX1HUAAAAAQKpjlWu4AAAAAAAWBq69e/dqwoQJT50/ceJE7du3z+KiAAAAACA1sChwzZgxQ3///fdT5wcGBmrGjBkWFwUAAAAAqYFFgevChQsqVarUU+eXKFFC58+ft7goAAAAAEgNLApcUVFRio6O/s/5Dx8+tLgoAAAAAEgNLApchQsX1pYtW544z2QyafPmzfL09HypwgAAAAAgpbMocLVs2VJHjhxR9+7ddf78ecXExCgmJkbnzp1Tjx49dOzYMbVq1SqpawUAAACAFMWi+3A1atRIAQEBmj59urZs2SKj8VFui4uLk8FgUKdOnfTBBx8kaaEAAAAAkNJYFLgkqWvXrmrYsKG2bNmigIAASVLevHlVo0YN5c2bN8kKBAAAAICUyuLAJT0KWG3btk2qWgAAAAAgVbHoGq7Tp09ryZIlT52/ZMkSnT171uKiAAAAACA1sChwTZw4Ufv27Xvq/AMHDmjSpEmW1gQAAAAAqYLFZ7jKlCnz1PlvvfWWTp06ZXFRAAAAAJAaWBS4wsPDZWdn9/SFGo0KDQ21uCgAAAAASA0sClz58uXT3r17nzp/9+7dypMnj8VFAQAAAEBqYFHg+uijj7Rjxw6NGjVKISEh5ukhISEaOXKkdu/erY8++ijJigQAAACAlMiiYeE//fRTnTt3TgsWLNCiRYuUI0cOSdLt27cVFxenRo0aqXXr1klZJwAAAACkOBYFLoPBoFGjRqlRo0bavHmz+cbH1atXV61ateTj45OkRQIAAABASvRSNz4uV66cypUrl1S1aOfOnZo9e7YuXbqksLAwubu7q0aNGuratasyZcpkbrdt2zZNmjRJV65cUa5cudS+fXt9+OGHCZYVFRWliRMnat26dQoPD1fp0qU1cOBAFSxYMMnqBQAAAID/YlHgioqK0uHDh+Xv76+wsDBlyJBBhQoV0ptvvilHR0eLi7l//75KliypVq1aKXPmzLp48aKmTJmiixcvat68eZKkQ4cOqWvXrvroo4/Ur18/7d+/X/3791eGDBlUp04d87JGjBghPz8/+fr6yt3dXTNnzlTr1q21YcOGBOENAAAAAKzlhQKXyWTS3LlzNXv2bIWEhMhkMpnnGQwGubi4qF27dmrbtq0MBsMLF9OoUaMEj318fOTo6KiBAwcqMDBQ7u7umjFjhkqWLKlhw4ZJenSWLSAgQJMnTzYHrlu3bunnn3/W4MGDzYN3lChRQlWrVtWyZcvUrl27F64NAAAAAF7UCwWu3r17a8OGDcqXL59atWqlIkWKKEOGDAoPD9e5c+e0fv16jR8/XmfPntX48eOTpMDMmTNLkqKjoxUVFaUDBw6od+/eCdrUq1dPv/76q27cuCEPDw/t2bNHcXFxCc54Zc6cWRUqVNCuXbsIXAAAAABeiecOXGvXrtWGDRvUpk0bffXVV4lufFyjRg117txZEyZM0Ny5c1W5cuVEZ6yeV2xsrGJiYnTp0iVNmzZN1apVk4eHhy5duqTo6OhE12F5enpKkvz9/eXh4SF/f39lzZpVrq6uidr9/PPPFtUEAAAAAC/quQPXypUrVbZsWX3zzTdPbWM0GtW7d2+dOHFCK1assDhwVa1aVYGBgZKkSpUqmc+WBQcHS5JcXFwStI9/HD8/JCTkiddpubi4mNu8DHt7i25flqTs7GxfAx5hWzxd/LphHT0d6yb5YFs8HZ/lZ2PdJB9si6fjs2wbzx24zp8/r549ez5X21q1amnSpEkWliTNmjVLERERunTpkmbMmKGOHTtq/vz5Fi8vKRmNBmXJksHWZSAZcXFJb+sSkj3WEVIC9tNnYx0hJWA/fTbW0av13IErJiZGTk5Oz9XW0dFRsbGxFhdVpEgRSVLp0qVVokQJNWrUSFu2bFGhQoUkSaGhoQnah4SESJK5C6GLi4vCwsISLTckJCRRN8MXFRdnUkjIg5daRlKwszPyYUkmQkIiFBsbZ+sykqX4/ZR19HR8lpMP9tOn47P8bHyWkw/206fjs5y0XFzSP9fZwucOXHnz5tWff/6pJk2aPLPtoUOH5OHh8byL/k/e3t5ycHDQ9evXVa1aNTk4OMjf31+VKlUyt/H395ck87VdBQsWVFBQkIKDgxMELH9//yS5D1dMDDso/ic2No594hlYR0gJ2E+fjXWElID99NlYR6/Wc3fgrF27tjZs2KAdO3b8Z7sdO3Zow4YNCUYIfBnHjx9XdHS0PDw85OjoKB8fH23atClBGz8/P3l6eppDXsWKFWU0GrV582Zzm+DgYO3Zs0eVK1dOkroAAAAA4Fme+wxXmzZt9Ntvv6lLly5q3LixGjVqlGhY+F9++UWrV69WgQIF1KZNmxcupmvXripevLi8vb2VLl06nTt3TnPnzpW3t7dq1KghSerUqZM+/fRTDRkyRHXr1tWBAwf066+/auLEiebl5MyZUx999JHGjh0ro9Eod3d3/fDDD8qUKZOaNWv2wnUBAAAAgCWeO3ClT59eCxYs0DfffKOVK1c+cXh1k8mkd955R2PGjFH69C/ej7lkyZLy8/PTrFmzZDKZlDt3bjVp0kRt27aVo6OjJKlMmTKaMmWKJk2apJ9//lm5cuXSiBEjVLdu3QTLGjBggDJkyKDx48crPDxcb775pubPn//E0QsBAAAAwBpe6MbHWbNm1dy5c3X8+HFt27ZNly9fVnh4uDJkyCBPT0+9++67Kl26tMXFtG/fXu3bt39mu+rVq6t69er/2cbR0VF9+vRRnz59LK4HAAAAAF7GCwWueKVKlVKpUqWSuhYAAAAASFW46xkAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAK3muwLVw4UJduXLF2rUAAAAAQKryXIFr1KhROnXqlPlx0aJFtX79eqsVBQAAAACpwXMFLhcXF925c8f82GQyWa0gAAAAAEgtnus+XD4+PpoyZYrOnj2rTJkySZLWrl2r48eP/+fzBgwY8PIVAgAAAEAK9VyBa/DgwRo5cqT27t2rO3fuyGAwaO/evdq7d+9Tn2MwGAhcAAAAANK05wpcWbNm1fjx482PixQpou+++07vvfee1QoDAAAAgJTOomHhR40apdKlSyd1LQAAAACQqjzXGa5/++CDD8z/vnTpkm7evClJyp07twoVKpQ0lQEAAABACmdR4JKk33//XaNHjzaHrXgeHh7y9fVV9erVX7o4AAAAAEjJLApcO3fuVPfu3ZUrVy716tVLnp6ekqTLly9rxYoV6tatm2bOnKnKlSsnabEAAAAAkJJYFLimT58ub29vLVmyRM7Ozubp1atXV8uWLdW8eXNNmzaNwAUAAAAgTbNo0Izz58/r/fffTxC24jk7O+uDDz7Q+fPnX7o4AAAAAEjJLApcTk5OCg4Ofur84OBgOTk5WVwUAAAAAKQGFgUuHx8fLVy4UEePHk007/jx41q0aJHKly//0sUBAAAAQEpm0TVcX3/9tZo1a6bmzZurZMmSKlCggCTpypUrOnHihLJmzarevXsnaaEAAAAAkNJYdIYrT548WrdunVq1aqXg4GD5+fnJz89PwcHB+vTTT/XLL7/Iw8MjqWsFAAAAgBTF4vtwZc2aVf369VO/fv2Ssh4AAAAASDUsOsMFAAAAAHg2AhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAK3nhwBUREaHGjRvrp59+skY9AAAAAJBqvHDgSp8+vW7cuCGDwWCNegAAAAAg1bCoS2GlSpW0Z8+epK4FAAAAAFIViwJX586ddfXqVX399dc6dOiQAgMDdf/+/UT/AQAAAEBaZm/Jk+rXry9JunTpkn799dentjt79qxlVQEAAABAKmBR4OrSpQvXcAEAAADAM1gUuLp165bUdQAAAABAqpMk9+EKDQ1VbGxsUiwKAAAAAFINiwPXyZMn1bZtW5UqVUo+Pj46ePCgJOnu3bvq1KmTDhw4kGRFAgAAAEBKZFHgOnLkiJo3b65r166pYcOGiouLM89zc3NTWFiYli9fnmRFAgAAAEBKZFHgmjhxojw9PeXn56devXolmu/j46Pjx4+/dHEAAAAAkJJZFLhOnjypxo0by9HR8YmjFbq7uysoKOiliwMAAACAlMyiwGVvb5+gG+G/BQYGytnZ2eKiAAAAACA1sChwlSpVSps2bXrivAcPHmj16tUqW7bsSxUGAAAAACmdRYGre/fuOnXqlNq3b69du3ZJks6fP6+VK1eqcePGunv3rjp37pykhQIAAABASmPxGa5Zs2bp2rVr6tOnjyRp9OjRGjhwoOLi4jRr1iwVKVIkSQsFAAAAgJTG3tInli9fXps2bdKZM2d07do1mUwm5cmTR8WLF3/iQBoAAAAAkNZYHLjivf7663r99deTohYAAAAASFUsDlxRUVFasWKFdu7cqZs3b0qScufOrSpVqqhJkyZycnJKsiIBAAAAICWyKHDdunVLn3/+ua5cuaLs2bMrX758kqRz585p9+7dWrx4sX788UflzJkzSYsFAAAAgJTEosA1dOhQ/fXXX5o0aZLq1KmTYN5vv/0mX19fDR06VDNmzEiSIgEAAAAgJbIocO3fv1+tW7dOFLYkqW7dujpz5owWL1780sUBAAAAQEpm0bDwGTJkkJub21PnZ8uWTRkyZLC4KAAAAABIDSwKXI0bN9aaNWsUERGRaF54eLhWr16tDz/88KWLAwAAAICU7Lm6FG7evDnB46JFi2rHjh2qW7eu3n//ffOgGVevXtUvv/wiV1dXeXt7J321AAAAAJCCPFfg6t69uwwGg0wmkyQl+PfMmTMTtb9165a++uor1atX74WK+e2337Ru3TqdPn1aISEhypcvn1q1aqUPP/wwwc2UV65cqTlz5uivv/5SgQIF1KtXL1WtWjXBskJDQzVq1Cj9/vvvio6OVqVKlTRgwADlyJHjhWoCAAAAAEs9V+BauHChteuQJP3444/KnTu3fH19lSVLFv3xxx8aOHCgbt26pa5du0qSNmzYoIEDB6pjx44qV66c/Pz81LVrVy1ZskRvvPGGeVk9e/bUpUuXNGTIEDk5OWnSpElq166dVq1aJXv7l77fMwAAAAA803Mlj7ffftvadUiSZsyYkWAwjvLly+v+/fuaP3++OnfuLKPRqMmTJ6t+/frq2bOnJKlcuXK6cOGCpk2bptmzZ0uSjh49qj179mju3LmqWLGiJKlAgQKqV6+eNm/e/MJn3gAAAADAEhYNmmEtTxr5sGjRogoLC9ODBw8UEBCgq1evqm7dugna1KtXT/v27VNUVJQkadeuXXJxcVGFChXMbQoWLKiiRYtq165d1n0TAAAAAPD/LO5bd+jQIa1atUo3btxQcHCw+ZqueAaDQevWrXvpAg8fPix3d3dlzJhRhw8flvTobNXjPD09FR0drYCAAHl6esrf318FChRIcN2X9Ch0+fv7v3RN9va2z6l2dravAY+wLZ4uft2wjp6OdZN8sC2ejs/ys7Fukg+2xdPxWbYNiwLX/PnzNXbsWDk5OalAgQJydXVN6rokPQp1fn5+6tOnjyQpODhYkuTi4pKgXfzj+PkhISHKlClTouW5urrq1KlTL1WT0WhQlizcYwz/4+KS3tYlJHusI6QE7KfPxjpCSsB++myso1fLosA1d+5cvfnmm5o5c+YTg01SuHXrlnr16iUfHx99+umnVnkNS8TFmRQS8sDWZcjOzsiHJZkICYlQbGycrctIluL3U9bR0/FZTj7YT5+Oz/Kz8VlOPthPn47PctJycUn/XGcLLQpcEREReu+996wWtkJCQtSuXTtlzpxZU6ZMkdH46I3En0kLDQ1V9uzZE7R/fL6Li4tu3bqVaLnBwcFJcjYuJoYdFP8TGxvHPvEMrCOkBOynz8Y6QkrAfvpsrKNXy6IOnD4+Prpw4UJS1yJJevjwoTp06KDQ0FDNmTMnQagrWLCgJCW6Dsvf318ODg7KkyePud2VK1cSXVd25coV8zIAAAAAwNosClwDBw7Uvn37NHfuXN2/fz/JiomJiVHPnj3l7++vOXPmyN3dPcH8PHnyKH/+/Nq4cWOC6X5+fipfvrwcHR0lSZUrV1ZwcLD27dtnbnPlyhWdOXNGlStXTrJ6AQAAAOC/WNSl8LXXXlPTpk01duxYjRs3Tk5OTuZuf/EMBoN5VMHnNXToUG3fvl2+vr4KCwvTsWPHzPNef/11OTo6qlu3burdu7fy5s0rHx8f+fn56cSJE1q8eLG5benSpVWxYkX169dPffr0kZOTkyZOnChvb2/VqlXLkrcMAAAAAC/MosD1/fffa+bMmXJ3d1fx4sWT7FquvXv3SpJGjx6daN7WrVvl4eGhBg0aKCIiQrNnz9asWbNUoEABTZ06VaVLl07QftKkSRo1apQGDRqkmJgYVaxYUQMGDJC9vcUj4QMAAADAC7EofSxbtkxVqlTR9OnTE53Zehnbtm17rnZNmjRRkyZN/rNNpkyZNHLkSI0cOTIpSgMAAACAF2ZRWoqOjta7776bpGELAAAAAFIbixLTu+++q0OHDiV1LQAAAACQqlgUuLp27arLly9ryJAhOnXqlO7evav79+8n+g8AAAAA0jKLruGqU6eOJOns2bNavnz5U9udPXvWsqoAAACAZMZoNMhoNNi6DIvZ2RkT/D+lioszKS7O9OyGyYRFgatLly4yGFLuzgYAAAC8CKPRoMyZnVN8WJEkF5f0ti7hpcTGxun+/QcpJnRZFLi6deuW1HUAeAKOpCUPKe1IGgAg6RmNBtnZGTVuyWHdCAy1dTlplod7JvVu8ZaMRkOK+W3mplRAMsWRtOQjpR1JAwBYz43AUF2+GWzrMpCCWBS4pk6d+sw2BoNBXbp0sWTxAMSRtOQiJR5JAwAAyUeSBy6DwSCTyUTgApIIR9IAAABSLosC17lz5xJNi4uL082bN7V06VL9+eefmj179ksXBwAAAAApWZJdHGI0GpUnTx716dNH+fLl04gRI5Jq0QAAAACQIlnlavyyZctq586d1lg0AAAAAKQYVglcp06dktGY8kdWAwAAAICXYdE1XGvXrn3i9JCQEB06dEibN29WkyZNXqYuAAAAAEjxLApcvr6+T52XJUsWtW/fnhEKAQAAAKR5FgWurVu3JppmMBjk4uKijBkzvnRRAAAAAJAaWBS4cufOndR1AAAAAECqw8gWAAAAAGAlz32G67333nuhBRsMBq1bt+6FCwIAAACA1OK5A1fmzJmfq11QUJCuXLkig8FgaU0AAAAAkCo8d+BatGjRf87/559/NHv2bC1fvlx2dnZq2LDhSxcHAAAAACmZRYNmPC4oKEizZs3SihUrFBMTo/fee0+dOnVS3rx5k6I+AAAAAEixLA5c8We0Hg9anTt3Vp48eZKyPgAAAABIsV44cP3zzz+aNWuWVq5cqZiYGDVs2FCdOnUiaAEAAADAvzx34Lp9+7Y5aMXGxqpRo0bq2LEjQQsAAAAAnuK5A1fNmjUVFRWlokWLqkOHDvLw8FBISIhOnz791OcUK1YsSYoEAAAAgJTouQNXZGSkJOnMmTPq2bPnf7Y1mUwyGAw6e/bsSxUHAAAAACnZcweuUaNGWbMOAAAAAEh1njtwffDBB9asAwAAAABSHaOtCwAAAACA1IrABQAAAABWQuACAAAAACshcAEAAACAlRC4AAAAAMBKCFwAAAAAYCUELgAAAACwEgIXAAAAAFgJgQsAAAAArITABQAAAABWQuACAAAAACshcAEAAACAlRC4AAAAAMBKCFwAAAAAYCX2ti4AAIDUzmg0yGg02LoMi9nZGRP8P6WKizMpLs5k6zIApDEELgAArMhoNChzZucUH1YkycUlva1LeCmxsXG6f/8BoQvAK0XgAgDAioxGg+zsjBq35LBuBIbaupw0y8M9k3q3eEtGo4HABeCVInABAPAK3AgM1eWbwbYuAwDwiqX8/g0AAAAAkEwRuAAAAADASghcAAAAAGAlBC4AAAAAsBICFwAAAABYSbIKXNeuXdOgQYPUqFEjvf7662rQoMET261cuVK1a9dWiRIl1LBhQ23fvj1Rm9DQUPXr109vv/22Spcure7du+v27dvWfgsAAAAAYJasAtfFixe1c+dO5cuXT56enk9ss2HDBg0cOFB169bV7Nmz9cYbb6hr1646duxYgnY9e/bU3r17NWTIEI0bN05XrlxRu3btFBMT8wreCQAAAAAks/twVatWTTVq1JAk+fr66tSpU4naTJ48WfXr11fPnj0lSeXKldOFCxc0bdo0zZ49W5J09OhR7dmzR3PnzlXFihUlSQUKFFC9evW0efNm1atX79W8IQAAAABpWrI6w2U0/nc5AQEBunr1qurWrZtger169bRv3z5FRUVJknbt2iUXFxdVqFDB3KZgwYIqWrSodu3alfSFAwAAAMATJKszXM/i7+8v6dHZqsd5enoqOjpaAQEB8vT0lL+/vwoUKCCDwZCgXcGCBc3LeBn29rbPqXZ2tq8Bj1hrW7CNkxe2c+rHNk4b2M6pH9s4bUhJ2yNFBa7g4GBJkouLS4Lp8Y/j54eEhChTpkyJnu/q6vrEboovwmg0KEuWDC+1DKQuLi7pbV0CXgG2c+rHNk4b2M6pH9s4bUhJ2zlFBa7kIC7OpJCQB7YuQ3Z2xhS1o6VmISERio2NS/Llso2TF7Zz6sc2ThvYzqkf2zhtsNZ2fhEuLumf60xbigpcrq6ukh4N+Z49e3bz9JCQkATzXVxcdOvWrUTPDw4ONrd5GTExtt24SF5iY+PYJ9IAtnPqxzZOG9jOqR/bOG1ISds55XR+1KNrsCQlug7L399fDg4OypMnj7ndlStXZDKZErS7cuWKeRkAAAAAYG0pKnDlyZNH+fPn18aNGxNM9/PzU/ny5eXo6ChJqly5soKDg7Vv3z5zmytXrujMmTOqXLnyK60ZAAAAQNqVrLoURkREaOfOnZKkmzdvKiwszByu3n77bbm5ualbt27q3bu38ubNKx8fH/n5+enEiRNavHixeTmlS5dWxYoV1a9fP/Xp00dOTk6aOHGivL29VatWLZu8NwAAAABpT7IKXHfu3FGPHj0STIt/vHDhQvn4+KhBgwaKiIjQ7NmzNWvWLBUoUEBTp05V6dKlEzxv0qRJGjVqlAYNGqSYmBhVrFhRAwYMkL19snrLAAAAAFKxZJU+PDw8dP78+We2a9KkiZo0afKfbTJlyqSRI0dq5MiRSVUeAAAAALyQFHUNFwAAAACkJAQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWEmqDlyXL1/W559/rjfeeEMVKlTQ2LFjFRUVZeuyAAAAAKQR9rYuwFqCg4P12WefKX/+/JoyZYoCAwM1evRoPXz4UIMGDbJ1eQAAAADSgFQbuJYtW6bw8HBNnTpVmTNnliTFxsZq6NCh6tChg9zd3W1bIAAAAIBUL9V2Kdy1a5fKly9vDluSVLduXcXFxWnv3r22KwwAAABAmpFqA5e/v78KFiyYYJqLi4uyZ88uf39/G1UFAAAAIC0xmEwmk62LsIZixYqpR48eat++fYLpDRo0UOnSpTV8+HCLlmsymRQXZ/tVZjBIRqNR90MjFRMbZ+ty0iR7O6MyZ3JSXFycrPEpYhsnD2zn1I9tnDawnVM/tnHaYO3t/CKMRoMMBsMz26Xaa7isxWAwyM7u2Sv2VcmcycnWJaR5RqN1TxSzjZMHtnPqxzZOG9jOqR/bOG2w9nZOSimn0hfk4uKi0NDQRNODg4Pl6upqg4oAAAAApDWpNnAVLFgw0bVaoaGh+ueffxJd2wUAAAAA1pBqA1flypX1xx9/KCQkxDxt48aNMhqNqlChgg0rAwAAAJBWpNpBM4KDg1W/fn0VKFBAHTp0MN/4+L333uPGxwAAAABeiVQbuCTp8uXLGj58uI4ePaoMGTKoUaNG6tWrlxwdHW1dGgAAAIA0IFUHLgAAAACwpVR7DRcAAAAA2BqBCwAAAACshMAFAAAAAFZC4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAEgyJpPJ1iUAQLJC4EKyExcXl+AxP95A2sHnPeWKjY2VJBkMBhtXAgDJC4ELyUpsbKyMxke75dWrVxUZGcmPN57L43+oP3z40IaV4EXE/5EeL/7zTvBKOeLi4rRhwwZt377dPK179+7avXu3DauCtUVHR9u6BCDFsLd1AUC82NhY2dnZSZIGDRqkoKAgValSRU2aNDGHMOBJTCaT+Q/1nTt36sCBA6pUqZLKly9v48rwXx7/zC9dulQBAQFydHTUO++8Ix8fHxtXh+dlMBh04cIFzZo1S+PGjdP69ev1559/qkOHDrYuDUkgLi5OO3fuVExMjGrWrClJGjVqlCpWrKhKlSrZuDokd4//PqdlBC4kG/F/ePXs2VMnTpxQ9+7dVb58ecIWnin+y3z16tUaMWKEGjVqxNHXZM5kMpk/8927d9fJkyfl5uYmo9GoWbNmqX379vroo4+UJ08eG1eKZzEYDOrVq5du376tfv36KV26dJo1a5aKFStm69KQBCIjI7Vp0yYdOXJEDx8+1IYNG3T48GF99NFHti4NydzjYev06dO6c+eOgoODVblyZWXIkEH29vZpJpARuJCsrF+/XocPH9Z3332nt99+m7CFp/r3l/Sff/6psWPHqlu3bvrwww/l4uJiw+rwLPHbbt68eTpx4oTGjRunIkWKKGPGjJo0aZJmzpypEiVKKHfu3HwPpBB2dnaKjIyUJF27dk3FihVTunTpbFwVLBUXF6eYmBilT59effr0UYcOHTRs2DDZ2dlp3rx5Kly4sK1LRDIX/z2/atUqjRs3Tvb29goLC1PWrFn1+eefq06dOsqaNauNq3w1+BWDTUREROjChQuJpl+7dk3Ozs4qUaJEgj+y/n09B9d34N9HxI4fP64sWbKoZs2ahK0U5OzZs3rjjTdUqlQpZcyYUVeuXNGKFStUt25dVapUibCVgnz66adavXq1atasqWHDhunXX3/VgwcPbF0WLBAZGam2bdtq69atevDggbJkySI3Nzc9ePBAGTJk0Pnz581t/z3QFfC4vXv36ttvv1XHjh01e/ZsHTlyRGXLltV3332n9evXJ7qON7XilwyvXHR0tDp06KA1a9Yk+qIOCQlReHi4MmTIIOl/X+SPX5/z4MGDNHH6GU82ZswYjR8/3vw4fh85c+aM7O3t5eHhkWB6vMDAwFdXJJ5LXFyc7t+/r7i4ODk4OOjKlStq2rSpfHx89O2338rJyUmTJ0/W8ePHbV0q/uVJfyR5eXnp9ddf16hRo1S9enWNGDFCfn5+5kFsHj58qHPnzr3qUmGB6OhoBQUFafTo0dq/f78kqWnTppoxY4ayZMmiefPmaeXKlZIko9HIQVA81fHjx1W8eHHVq1dPRYoUkcFg0P379+Xu7q4KFSrIzs4uTYR2AhdeOQcHB3322Wfq2rWrjEaj/vrrL/O8119/XQ8fPtRPP/2kmJiYBEe3z507p/Xr1+vMmTO2KBvJQGhoqOLi4lSlShXztPh95K233lJAQID27dtnnh7/R8CNGzc0derUBEdl8Wo96XYPRqNRuXPn1pkzZ3To0CE1a9ZM5cuX1/Dhw+Xs7KyAgAAdPnxYR48eTRM/yCnF44OdrFmzRuPHj9fEiRN16NAhSY++40ePHq3q1avr22+/1dq1a3X27FmNHDlSrVq1UmhoqC3Lx3PImDGjlixZorx582rAgAHavn27KlasqMqVK2vatGlydnbW/PnzzaHLYDAoMjJS586dU1RUlI2rh6086UDM6dOn9eDBA2XPnl2S9MUXX+jMmTP6/vvvVbhwYR09elQnT5581aW+cgQuvFLxfwBXr15dGTJk0MSJE9W1a1edOnVKklSzZk0VKFBAs2fP1oYNG8zPu337thYuXKgzZ84ob968NqkdtpcpUyZ99dVXKlOmjHbs2KFhw4aZ53l5eSlnzpxavHixeX8yGAyKjo7WH3/8oWPHjjGQho08fruHkJAQhYWFmc9Sd+rUSSaTSS1btpSPj4/GjRunjBkzKigoSNOnT1dQUJBq1qxJ18JkIi4uLsEARzNmzNChQ4d0+vRptW7dWps2bZL0v9BVq1YtDRkyRN26ddP27ds1b948ZcqUyZZvAc8Q/zvt4uKiadOmydPTUwMGDNDu3bsVEREhd3d3TZ06VRkyZNCPP/6opUuXKjAwUCNGjNDQoUPN1/Eh7bh48aJu3bpl/m7Yu3evTpw4IUkqXry4IiMjde3aNbVv316XLl3SzJkzVaRIEd27d08LFizQwYMHFRMTY8u3YHUGE+eB8Qo9fmRUkubMmaNVq1bJw8ND3bp1U8mSJRUSEqIWLVrozp07ypcvn3LlyqWbN2/qypUrWrBggYoUKWLDdwBbiR8kw2QyKSoqSsOHD9emTZv04YcfytfXV5K0ZMkSzZgxQx4eHmrWrJmyZMmiU6dOac6cOerSpYu++OILG7+LtOfxwU0GDx6sU6dO6c6dO2rTpo2qVasmDw8P/f777xo/frzs7OzUoUMH3b59W8eOHdOBAwe0cOFCPvPJ0IgRI7Rz506NHj1ab731lsaNG6c5c+ZIkr799lt9+OGH5rbr169XTEyMypQpw6iTyVxcXFyigxshISHq0qWLrly5omHDhql8+fJKnz69bt26pV69esnf318ZM2ZUZGSkZsyYoRIlStioetjC3bt3NW/ePB08eFCzZ8/W7t271b9/f02aNElVq1bVkSNH9OmnnypjxoxydnbWDz/8oMKFCys6Olq//vqrpk2bpr59+6p69eq2fitWReCCTaxatcr8g7x8+XLNnz9fuXPnVvfu3VWqVCmFhYWZRy978OCBvL291apVKxUsWNDGlcPW/vnnH2XPnl1///235s6dq82bN6tWrVoaMGCApEddnNauXasDBw7IwcFBefPmVZMmTdS6dWtJ3BPkVXr8AEv//v31xx9/qGbNmgoKCtJvv/2mxo0bq3379sqXL5/OnTunUaNG6e7du4qNjVXRokXVsWNHRkJLhi5evKhRo0bpww8/VP369TV37lxNmDBBffv21bFjx/Trr79q/Pjxql+/vq1LhYUGDhyocuXKmbfh00JXUFCQNm/erMjISFWrVk358uWzceWwhdWrV2vBggV68OCB/vrrLw0ZMkSNGjWSg4ODDAaD1q9fr6+//lqVKlVShw4dlCFDBu3Zs0fTp09Xp06d1L59e1u/BeszAa/Y0qVLTW+//bYpPDzcPG3ZsmWm2rVrm9q0aWM6duyYyWQymeLi4sz/j/830rZdu3aZqlatarpz547JZDKZbt26ZRoyZIipUqVKpuHDh5vb3blzx3T16lXTpUuXTH/99Zd5emxs7CuvGSZTaGioacyYMabdu3ebYmJiTCbTo++BkiVLmr7++mvTpUuXzG0DAwNNYWFhpsjISFuVi2cICgoyrVmzxhQaGmrasmWL6c033zStWrXKZDKZTAcPHjR5e3ubXn/9ddOKFStsXCkscffuXVPbtm1NJUqUMG3ZssU8PTg42NSyZUtThQoVTFu3bjU9ePDAhlUiuRk8eLDJ29vbVLVqVdP58+dNJpPJFBMTY/777bfffjNVrVrVVKlSJVPZsmVNjRo1Ms2fP9/8/NT++8wZLrxy27dvV7du3fTLL7/I09PTPP3xM129evVS8eLFbVglkqMlS5Zo2rRp2rZtm/n+PoGBgZo5c6a2bt2a4EzXv5k4s2UT48eP17x58/Taa69p6tSpCboHLl++XCNHjlTdunXVpk0beXl52bBSPMmTuphJUlhYmDJmzKh+/frp3r17GjdunHl02RYtWigoKEj379/Xli1buE1DMvek78abN29q4sSJ2rRpkyZOnKgaNWpI+t+ZroCAAPXt21dVq1aVo6OjLcpGMhETEyOTyaSRI0cqKipKJ0+elKOjo8aMGSNPT0/zNbwGg0G3bt1SaGioIiMjlTVrVr322muSnv49k5qk7ncHm3vSiDUeHh5Kly6dgoKCJMk8kEHTpk31+eef6/bt2xo2bBjDB6dxTzoW5OPjo4iICPPFuLGxsXJ3d1fHjh1VvXp1bdu2TcOHD3/i8ghbtlGwYEGVLFlSd+7cMX/W40cxa9q0qfr166ctW7ZoypQp8vf3t2Wp+JfHBzu5cOGCzp8/r6tXr0p6NIqdyWTS3bt3FRoaKgcHB0nS5cuXZTQa1b9/f/3222+ErWQuLi7O/N34+GAX8Qc+a9WqpV69eun333+X9L+BNFxdXTVx4kQGIkqjHv99tre3l4ODg/r06aNvv/1Wn332maKiotSnTx9dunQpwbDvzs7OKly4sIoXL24OW6b/H7E2tUv97xA2FX/9xk8//aQ1a9YoICBA2bNnV86cOXXw4EFJMv9QS4/+APvwww8VFxfHD3UaF/9HwJUrVxQcHKzY2FjzsLLxYT1+EI340FWxYkWtWrXKPDw1Xq0nDd3eqFEjtWrVStmzZ1ePHj0UFBQkR0fHBKGrR48eOnr0qPkMCWzv8dEIv/nmG3Xv3l1NmjRRmzZtNGLECEVGRspgMKhkyZK6cOGCZs2aJT8/P82fP1/3799XsWLF5ObmZuN3gWeJ/0N39OjRmjJlisLCwszzcufOrS+//FI1atTQV199pe3bt0t6FLoWL16suXPn8plNgx4/I/rXX3/p6tWrun79uvn74sMPP1SrVq0UHR0tX19fXbt2TXZ2dvr99981YMCARPfETCsHQ+lSCKvbsWOH+vTpo5iYGBkMBhmNRoWEhKhSpUqqUKGCypQpIxcXF+XKlUv29vaSHnVbIHBh9+7d6t69u+zt7VW4cGGVKlVKK1asUO3atdW+fXvlzZs3wZGxwMBAXb16VT4+PjasOm16fICMGzduyMHBQUajUdmzZ1dcXJw2b96siRMnymg0atGiRcqWLZuioqLM3ZH4zCdP/fv31969e9WnTx85OTkpPDxcffv2VZUqVfTdd9/J2dlZvr6+2rZtm0wmk1xdXTVlyhQVLVrU1qXjP/y7G+Gnn36qa9euqVmzZmrVqpUyZsxonnfy5El17txZUVFRGjp0qOrUqWOLkpHM/Prrr5o+fbpCQ0N17949ffzxx2rUqJFKlSolSfr555+1aNEi3blzR9WrV9eqVavUpUsXderUycaV2waBC0nuSX1x79+/r7i4OF24cEFXr17V2rVrdebMGWXNmlV37tyRyWRSrly59MYbb2j06NFp5ogH/tu9e/d08uRJXb9+XVevXtXRo0d17do1xcXFKTo6Wvnz51fu3LlVqFAhFS1aNMGoaGmhT3hy8fi67t+/v06cOKHbt28rR44catasmVq0aCGTyaRNmzZp0qRJkqTFixcnCF1cY5f8XL58WT179lS7du1Up04dOTo6yt/fX40aNVL9+vU1aNAgOTs7S5KOHj0qOzs75cyZUzly5LBx5fgvjx8cefxAR8+ePXXkyBE1a9bMPIx3vPbt2+v48eOys7PT5s2bE8xD2rNhwwYNGDBAbdu2VdOmTbV8+XLNmjVLlStXVps2bfTmm29KkjZu3KhNmzbp1q1batiwoT755BNJafOaantbF4DU5fEv8rt37yo6OlpZsmRR5syZJUnlypVTuXLlFBkZqQsXLmjdunW6efOmrl+/rnPnzqlu3bpp7kOIR570BZwlSxZVrlzZ/DgqKkrff/+91q9fr0GDBuns2bM6duyYtm3bpqxZsyZ4LmHr1Ylf1998840OHDigbt26KS4uTv/884+GDx+ugIAAffXVV6pdu7Ykadq0aWrYsKF+/fVXc7czPve29+/7JD548EDXr1+Xq6urHB0ddfXqVTVr1kw1a9bU4MGDlT59eu3atUuVK1dW6dKlbVg5ntfj23jq1KmKjY1V7dq1VaRIEU2aNEk9evTQsmXLZDKZ9Pnnn8vZ2Vk3btxQunTpNGnSJHl7exO20rjLly9r0aJF5uHcz58/rwULFqhEiRLau3evIiMj1blzZ5UuXVp16tRRrVq1FB4ebr7heVo9GErgQpJ5vM//iBEjdPDgQQUGBipnzpzq2LGjfHx8zH9c5cuXT/b29oqMjFSRIkVUpEgR1apVy5blw4YeD1t79uzRH3/8oevXr+utt95SpUqVVKhQIUmSo6OjSpcurWXLlumdd94xj5wVP2IabOfkyZM6efKkBg4cqCpVqsjBwUEXL17UlClT9ODBA/PF+bVq1dLDhw+1ePFihYWFcZ1PMmEymczf3z179lSbNm2UIUMGGY1GOTk5mbsMvfPOOxo2bJjSp0+vPXv2aObMmcqVK5f5M4rk69/b+OTJk2rVqpWyZMlibvP999+rZ8+eWrlypS5cuKB33nlHBw8e1MWLF1WoUCE+r1B0dLRy586tDz74QAEBAWrTpo1q1KihUaNGacmSJRo+fLjSp0+v6Ohovf322zIajeawlVYGyHiStPmuYRXxH6KvvvpKW7duVb169fTFF18oe/bs6t27t3788Ufdvn1bklS8eHE9fPhQx44ds2HFSC7iw9bq1avVrVs3/fnnn7p9+7bGjx8vX19f/fLLL+a2rq6uevDggW7evGmeFh+26CFtO6Ghofr777+VPXt2OTg46Nq1a2rRooXq16+vvn37ysnJSWfOnJHRaFTDhg31448/Km/evLYuG3p01iP+Mzh9+nTt27dP9+7dk6enpypVqqRu3bqpWrVqql69ur799ltlzJhRd+/e1YYNG5QhQwZly5bNxu8AzyN+G48cOVInT57UhAkT1KRJE7m7u8tkMikmJkaSNGnSJNWrV0/+/v6aMGGCLl26pIkTJ5oHLULaVqRIEXXr1k3Zs2fX7NmzlT9/fnXv3l2S1LhxY+XNm1cHDhzQtGnT9M8//yR4blruycAZLry0x89OHDlyRIcOHVK/fv3M3YfatWunMWPGaO7cucqVK5eaNWsmR0dHOTo6JhqtBmnXhQsXNG7cOHXq1ElNmzaVq6urzp07pz59+mjevHnKlCmTqlWrpmLFiil79uw6efKkChcunGAZafnL/FV6UpeQ6OhoGQwGubu7659//lGTJk0SnA3ZuHGj+b5br732Gmckk5H4sx6nT5/W5cuX1atXL5UvX16S1KpVKwUHB+vw4cP64IMPZG9vr3Pnzmn+/PnauXOnFi9ebO4yjuQvPDxcZ86cUcOGDc2DGwQEBGjJkiUKDg5WyZIl9cknn+ibb77RZ599prCwMGXJkoUzW2nQ491Po6KiZDKZ5OTkJEnKnz+/oqKidPHiReXNm9c8xHtQUJDc3d1Vp04d5cmTh5D+GAIXLPJ4yIr/f1xcnCIiInT79m3zCFXR0dHm+zPcvn1b06ZNU506dZQ5c2bVqlVLb7/9ts3eA5KH+H3pn3/+kclk0rvvvitXV1fFxcWZryv47LPPtHLlSlWrVs38HG62aRuP/wjv3r1brq6uKlmypKpUqaJ8+fKpTZs2CgoK0rvvvqtBgwYpQ4YMCgoK0o4dO5QpUyaCVjI1fvx4zZkzRx4eHmrRooX581W2bFm1adNGdnZ2+vzzz5UrVy45OTkpJiZGP/74I10JU5iYmBhduXJFRYoU0fnz53XgwAFNnDhR7u7ucnBw0Jo1a5QuXTp98MEHcnd3l7u7u61LxisWEBCgPHnymP+2++2337R69WrdvXtXderUUePGjZU1a1Y5OjrKw8NDe/fuNd9O4MiRIwoPD1e7du0SdCPkYChdCmEBk8mk33//XbNmzTJP69Onj+bPny8nJydlyJBBf/75p0wmkxwcHMz32/n4448VHBys06dPS5IGDx6c6AwF0o74G2bG/z8yMlL37t1LcCPN6OhoFShQQP3799eOHTt0/PhxOTs7a+nSpWrQoIFN6k7LHr9O86uvvtL48eO1c+dO3b9/X5LUsWNH2dnZKTY2Vj179pSzs7OuXLmi8ePHa/fu3erRo4f5RxjJS6dOnfT6668rICBAW7ZsSXAT3CpVqmj27Nn6/vvv1a5dO/Xp00cLFy5UkSJFbFgxniU2NjbRNFdXV3Xv3l2LFy/Wp59+qjlz5qh169Zat26dZs6cqaJFi+rs2bM2qBbJwZIlS/Txxx/rzz//lNFo1KZNm+Tr6ys7OztlzZpV33//vYYOHaoLFy5Ikpo3by4XFxeVLVtWLVu2VP/+/VW7du0E3/OErUc4w4UXFh0drevXr+vHH39UUFCQbty4oePHj6tt27bKmTOnsmXLppUrV6pYsWLy8vIyHyl9+PChMmTIYB6CNv7UNNKOU6dOad++fWrXrp0cHBy0cuVK7d+/XyNHjlS+fPmUM2dOLV26VD169FCOHDnMX9ROTk7m/yQpT548ktLuaEe2Er+u+/Xrp6NHj2rw4MEqVaqUuUvZu+++q4iICM2cOVONGzeWu7u77OzsdP/+fc2ZM0eenp42rB7x/j0aoSQ5OztryZIlatasmdasWaNSpUqpRo0asre3Nw+2ED9IDZK/x7fx3r17FRoaqjfffFOZM2dW06ZNVaRIEYWEhMjNzU3FihWTJKVPn14ODg5ck5eGZcmSRXny5NGwYcM0ePBg3blzRx07dtQXX3whBwcH7dq1S926dVNkZKR8fX1VunRpTZ48WevXr1dkZKTatWtnvj0LZ7YSInDhhTk6OqpJkyYKCgrSkiVL5OTkpEWLFsnLy0vSo64pn332mUaOHKnWrVurWrVqun79ujZu3Cg3NzflypXLxu8AthAXF6e7d+9q/vz5Onz4sGrUqKGBAwdqwIABcnJykqenp9577z3Nnz9fr732mt5//315eHgoMjJSN2/eVNasWeXg4JBgmYStV+/8+fPav3+/unXrpkqVKpm3QVxcnNKlS6eGDRuqWrVqWrt2rcLDw5U3b1699dZb5j7+sK3IyEjzgYtDhw7p4cOHeuONN5QxY0alS5dOS5cu1UcffaQxY8bIYDCoevXqsre35+BGCvP4aIT79u1TcHCwcuTIoebNm+vjjz9WqVKlEvxBfPPmTc2YMUO3bt3ixsZpWL169eTk5KTZs2dr0KBBio2NVadOneTg4CCTyaTKlSvrhx9+UIcOHTRq1Cj5+vqqUKFC6tWrV4KQz/dFYtz4GBYbM2aMfv75Zzk4OKhu3boaOHCged6xY8fMR0EMBoOyZs2qe/fuaf78+XRDScPCwsK0ZcsWDRs2TNHR0erbt69atGhhvvmt9Kir6bp161SgQAGVLVtWISEh8vPzU9euXdWuXTsbvwPs2rVL7du31+bNm5U3b17zDytHM5OviIgIzZ49W127dk0wmuyOHTv04MEDZcuWTb6+vqpQoYIyZ86sBw8e6KOPPlJERIT69eund999N9HBDiRP8ddNS9LKlSs1d+5c9e7dWwUKFNC0adN07Ngx1a5dW+3btzcPBz9r1izt2bNH165dM3crRNrz+Hf4li1btHDhQh07dkzDhw/X+++/b+6iamdnp/3795vvtdW7d2/2medA/ITFWrZsqVmzZql+/fr6/fffNWzYMPO8N954Q6tXr1afPn3UqlUrtWjRQitWrCBspWEmk0kZM2ZU9uzZFRsbK6PRqB07dkh6dNb04cOHkqShQ4eqd+/eyp07tzZt2qS7d+/K19fXHLY4RvTqxMXFJZrm5uYmo9GoU6dOSXp0ljH+HluStGHDBu3bt8/cnu1leytXrtTs2bM1YMAASdKvv/6qU6dOacyYMZo9e7bKli2rfv36acOGDbp7966cnZ31888/K2PGjPrmm2+0e/duG78D/Jfw8HDzZy4+bMXfSuP9999XjRo15OnpqQkTJqhSpUratGmTZs2apXv37ikqKkrp06dXgQIFtGDBAv5wTsMMBoP5+7pmzZpq3bq1ChYsqLFjx+rPP/+UnZ2djEajYmNjVa5cOU2bNk179+7V33//bePKUwbOcOGl3b17V9OnT9eWLVtUrVo1DR482Dxv27ZtqlixIiPKwezs2bMKDAzU9evXNX36dBUvXlxz5syRlLC7kyTdv39fzs7O5v2HbgqvzuPdQw4dOqTSpUvLzs5ON27cUPv27ZU3b159+eWX5q7EJpNJf//9t0aPHq0yZcqoRYsWia4Tgm3cvXtXCxYs0Lp161SuXDnlz59fktShQwdzm/79++uXX35R3759VbduXbm5uSk8PFyff/65xo4da34OkheTyaQvv/xSBoNBY8eOlb29vQ4cOKDPPvtMktSrVy916NAhwZmvwYMHa/fu3apbt67at28vV1fXRN+9SLseP9O1bds2/fDDDwoLC9OQIUNUtmxZmUwm8wBKt27dUs6cOW1cccpA4EKSCAoK0syZM7VlyxZVrlxZ7dq105w5c/THH39o6dKlypEjh61LRDLz4MEDrV69WlOnTk0QuuLi4nTy5EnlyZMnwb1f6LL26jwetvr376+zZ8+qfv36atu2raRHZ7G++uor1a5dW02aNFHFihV19uxZLV26VNu3b9eSJUuUL18+W76FNO/fn5fIyEh99913OnTokAICAtS/f381btw4QXfe+NAVfx/FrFmz8rlLAQIDA5UpUyY5Ozvr0qVLKlSokJYvX64pU6aoYMGCmjNnjhwdHROErmHDhmnNmjX67LPP1L17dw5kIYHHP/e///675syZo5CQEA0bNkxlypRJ9L3AwdBnI3Ahydy5c0dz5szRzz//LEdHR9nb22v69OnmEZCAePFf1mFhYVq7dq2mTp2qEiVKaMSIEfrzzz81dOhQjRgxwnzzbNhGr169dPz4cfXr109FixZV7ty5zfPWrl2r8ePHKyQkRM7OzkqfPr1iY2O5BiQZiL91x5UrV9S+fXtJ0ogRI5Q+fXrFxMRo+fLlKl68uBYuXChJCULXoEGDtGLFCg0fPlwffvihDAYDgSuFmD17tqZPn65p06bpnXfe0bJlyzRy5EjVrFlT48ePl5TwGq/Ro0frk08+4eAInujfoWvevHn6559/NGzYMPON0fH8GKUQSSZr1qzq3Lmzqlevrhs3bqhs2bIJ/kAD4sX3Fc+YMaM++OADGQwGTZkyRY0aNZLJZNJnn31G2LKxn3/+WceOHdOECRNUsmRJ2dnZ6cGDB7p9+7ZcXV31/vvvq2jRorp06ZLOnz+vwoUL68033+Qznwz8+9YdAQEBOnbsmJYvXy43Nzc5OjpqxYoV8vX11ahRo+To6GgOXcOGDZOjo6PefPNNjlinMNWrV9euXbs0dOhQDR48WM2aNZMkffvtt+b75sXfG9PR0VG+vr42rhi28O+zU0+6TYT0v99pg8GgGjVqyGQy6fvvv9ft27dfZbmpBme4ANhM/Jd5ZGSkzp8/r1OnTil37tyqUqWKJLop2NK8efO0evVqLVy4UG5ubjp06JBGjhype/fuKTIyUsOHD1f16tVtXSaeIiQkRDNmzEhw6474QYtCQkI0a9YsbdiwQT4+Pho9erSkhGe6kDJdv35d/fv3161btzR06FDzma5vv/1WdevW1dixY21dIpKJM2fO6PXXX39mu8cDWkBAgPk+mHgx/CUDwGYev7FxyZIl1bx5c8KWDTx+3C3+30ajUbdu3dL06dP11VdfqU2bNnrttdfUoUMHFS9eXN9++60iIiJsVTKe4fEbzMffZPzxee3bt1f9+vV14MAB9e/fX5IIW6lA3rx59e233ypnzpwaPHiw/vjjDzVr1kwDBw7UunXrEty+BWnXuXPn1L59e+3cufOZbQ0Gg3nE2viwxbmaF0eXQgBJIqkvridsvRoxMTGyt//fT0H8NmzdurUuXbqkAwcO6LXXXtOAAQP08ccfm9vcuHFDDx8+VPr06W1SN56tZcuWqlWrlvz8/LR582aZTCYNGjRI0v9Cl9Fo1PLly2VnZ5fg1h5IueJDV//+/TV48GANGzZMH3/8sezs7PTGG2/YujwkAxkzZpTJZNKRI0fMBzn/y7/vtch1nS+OLoUAXtrjX8THjx/XX3/9pbt376pq1arKmjXrcw03zGhor058n/3H1/nMmTN1/vx5ubq6qnDhwmrRooWkR/f4ib/eTno0VP/w4cN17949TZ06Vc7OzjZ7H3g+j9+6o3r16ubQJUmrV6/WxYsX1bx5c7oKpTLXr1/XoEGDdObMGU2ZMkU+Pj62LgnJQHzvkQULFmj69On68ccfnznQ0eO/FStXrlTBggX11ltvvYpyUw0OIQN4afFfxD///LPat2+v7777TpMnT9ZHH32kBQsWKCAg4D+f//iX+a5du3T16lVrl5xmRUVFqVmzZlqxYoV5nX/55ZeaP3++goKCdOLECY0aNUpdunTR7du3lSFDBnPYOnz4sMaMGaM9e/bI19eXsJVCuLm5qWPHjqpZs6a2bt2qgQMHmq/1WbhwoT777DPCViqUN29eDR48WG+++Sb3SoKio6MTPC5durQyZ86sQ4cOSXp0IO5JHv99Xrx4sQYOHKi//vrLusWmQnQpBJAkDhw4oNGjR6tbt26qWLGiPD09NW7cOH3//feKiYlRu3btzMMRP+7xL/MFCxZo1KhRmj9/PjdatZKIiAjlyJFDo0aNkpOTkwoXLqyrV69q0qRJKl++vMLCwrRv3z4NGjRIgwYN0syZMyVJK1as0PTp0+Xm5qaFCxeab3iMlCFbtmzq1KmTHBwc9PPPP2vbtm2yt7fXtGnT+GM8FStQoICmTJnyxO9epG6P/7Zu3LhRx44dU/369VWiRAlJUsmSJfXmm29q3rx5atq06ROv4Xx8GQsXLtSoUaM0YsQIvffee6/ujaQSBC4ASeLMmTMqVKiQ6tSpI3d3d0nStWvXlCtXLtWoUUMODg6Jhp99/Mt80aJF+u6777jHh5W5urpq+PDh+u677zR48GB9/PHHypYtm/najowZM6pmzZpKly6dunTpoqlTp6pr1676+OOPlSVLFpUsWdK8fZGycOuOtImwlbZERkbKycnJ/NsaExOjCxcuaOfOnVq8eLEaN26ssmXL6r333lPbtm118uRJLV26VJ999lmCbv3//n0eNWqUhg0bpo8++sgm7yulI3ABeGGPfxEHBQUpW7Zsunz5su7fv2/+Y/yLL77QpUuXNHPmTHl5eenQoUOKjY3V22+/neD+HtKjL/ORI0dq2LBhatKkic3eV2oXv87d3Nz01VdfyWg0auHChfLw8NC9e/cSDIDx9ttvq0aNGjp48KDCwsLMQQwpW6ZMmVSmTBmVKVPG1qUASGLnzp3TunXr1LhxYxUqVEgLFy7UypUrtX79erVs2VK7d+/WTz/9pG3btunnn39W3bp1ZTKZdObMmUTXUD/e82TMmDH8Pr8kruEC8MLiv4iXL1+uwYMHKyAgQN7e3oqNjdW5c+fUrl07Xbx4UTNmzFCRIkUUEhKiZcuWaf/+/eZ+5I93Uxg9ejRf5lYWGxub4Ac1W7Zs8vX1VYsWLXTjxg1t3rw5QR9/Jycnubm5KTAwkMFMACAZM5lMMplMcnZ21u7du9WjRw9NmzZNY8eOVf369WUymeTm5qZGjRpp6tSpmjp1qoxGo3799VddvnxZ69at06ZNmxIt18/PT999952GDBnC7/NL4gwXgOf2+FmpwMBAzZw5U02bNpWHh4cqVaqkSZMm6ZNPPlHmzJk1a9YseXt7KyoqSlu3btWRI0dUu3btBP3Ef/nlF40cOVLDhw/ny9yKHu/K6efnp9u3bysqKkrvvfee2rVrJ5PJpHHjxildunSqVauW3NzcdPv2bXOXUAIXACRf//zzj3LkyCEPDw/Nnj1bjRs31owZM9S2bVt16NAh0cG2bNmyaf78+Tpx4oQOHjyoefPmaceOHeZeDPG3ZXF3d9ekSZNUo0YNm7yv1ITABeC5xX9p79mzR5cuXVLRokX1wQcfyGAwKH/+/Jo8ebK6du0qd3d3/fXXX3rw4IH279+vWbNmqVOnTuYv8/jgFhYWpu+//161a9e25dtK1Uwmkzls9ejRQ8ePH1dkZKRiY2M1b948derUSc2aNZMkDRkyRBs2bFDevHl17949nT59WvPmzWM0QgBIpqZNm6Z169ZpzZo1cnZ2VmhoqMLDw5UhQwZt3bpVDRs2lKenZ4LnxA8NX7JkSZUsWVIuLi4aMmSIOnXqpLx585rbMfR70uE+XABeSGBgoDp16qSAgAB5enpq2bJlkv53A91Dhw5p8ODBioiIUHBwsAoWLKj33ntPn376qaT/fdHj1Zo4caJWrVqlCRMmyMPDQ3Z2dho7dqx+//13denSRXXr1tX8+fO1dOlSFStWTG3atFGJEiUS/PgCAJKXPXv2yMXFRSVLljQHrTNnzigmJka+vr6ys7PThAkTVLhw4UTPjYqKkqOjowIDA/XRRx/p66+/VsOGDW3wLlI/AheAF7ZhwwYtXrxYR48e1Zw5c1SxYkWZTCbFxcXJzs5O9+/fV1hYmB4+fKjMmTMrW7ZskghbthIVFaVu3bopW7Zs+vbbbxPM69u3rzZt2qSlS5fKw8NDgwcP1oEDB/T7778rXbp0NqoYAPBfHu/iL0l79+5Vr169tHTpUhUqVEgxMTE6d+6cvvnmGxmNRk2aNEmFChWSJO3cuVMlSpSQm5ubJOnUqVNq0qSJJkyYoLp169rk/aR2/OUD4Kmedjymfv36atOmjYoUKaIhQ4bo0KFDMhgMMhgMio2NVebMmeXh4aFChQqZw5bJZCJs2dDt27cVGhpqfhw/QMawYcOULVs2LVy4UBkzZlS/fv20atUqwhYAJGMGgyHBQEf29vZyc3NTu3btdPnyZdnb26tIkSIaO3as4uLi9OWXX2rz5s36+eef1aFDB23YsEHSo2Hkd+zYocqVKxO2rIgzXACe6PGjZ8eOHdPly5dlMBiUK1culStXTpK0adMmzZs3T2FhYRo6dKjKlCmT6KgbbC8mJkYDBw7UoUOHNH78eJUsWdI8LzY2Vi1atFD27Nk1ZcoUG1YJAHiWEydO6PLly/rggw8kSatWrdL169fVq1cv7dq1S5MmTdI///yjH3/8UZ6enoqJidH58+fVr18/XblyRRkzZlTr1q3Vvn178zIDAwPNt3ShJ4p1ELgA/KfVq1fr22+/Vc6cORUUFCQnJydVqlTJ3DVty5YtmjNnjiIiIjRw4ECVLVvWxhXjSc6fP6+PP/5YFStWVI8ePeTl5SVJunv3rrp27arixYurb9++kkRgBoBkKCYmRps3b1b//v3VvHlzFS1aVL1799bAgQPVokULSY+6C37//fcJQpf0qFfDH3/8Yb6Bffzy7O3/N34eB0yth8AF4KkOHTqkLl26qF27dnrvvffk7Oxs/rLv2rWrunbtKulR6JoxY4aCgoL0888/K3v27HxpJ0M7duxQ9+7dVahQIVWrVk3u7u7avXu39u/fr2XLlqlgwYK2LhEA8B8CAwO1Zs0aTZ06VdKj0WU/+uijBOHpaaHrcZzJerUYFh7AU504cUK5c+dWgwYNzN0NfvvtN+XNm1fvvvuuuV3NmjUVGRkpo9GoHDly2KhaPMu7776rxYsXa8yYMfrpp5/k6Ogod3d3LVy4kLAFACmAu7u78uXLp5iYGBmNRp09e1bSo2u44kcdrFKliqRHQ8a3aNFCixYtSjRKIWHr1SJwAZD05K4E169flyTlzJlTktSuXTtdvHhRP/zwg4oUKaK9e/fq9u3b+uCDD9SgQYP/XBaSh5IlS2rWrFkKCwtTXFycMmXKpIwZM9q6LADAM8TfxN7FxUWjR4/W5cuXtWDBAhkMBg0YMECOjo4JQpfRaNTgwYN17NixJw4Lj1eHwAVA0v+u29m3b5/eeustOTo6ytvbW6tWrdK1a9c0fvx4XbhwwRy27t+/r127dsloNCosLCzBH+2EreQtQ4YMypAhg63LAAA8w+MHMCMjI+Xs7KwKFSpIkm7duiWj0aj58+dLkjl0xcXF6cqVK6pUqZKWLVtGz5NkgPOJAMz++usv9e7dWzNnzpQkVapUSUWLFlWjRo106NAhrVixQkWKFFF0dLS2bt2qzZs3q1SpUpwhAQDACuLD1u+//66vvvpKnTt31rx58xQeHq6cOXOqadOm+vzzz7VixQqNHDlSkZGR2rhxo1q0aKF9+/aZwxZDNtgWZ7gAmGXJkkVFihTR4cOHFRcXJw8PDzVr1kyLFy/WvXv3dP36dV24cEFnz57V9OnT1blzZ9WpU8fWZQMAkGpt2bJFvXr1UqVKlRQQEKBz585p//79Gj9+vHLlyqWmTZvKYDBo1qxZ2r59u+7du6fWrVurfPny5mXQ88S2GKUQgKT/DQ975swZNWvWTF9//bVatWol6dGRtbVr12rv3r1Kly6d8uXLp/r165vnM9oRAABJLzQ0VBMmTFDWrFnVvn17OTo6av78+eaugtOnT1emTJl0584dnTp1SsePH1eRIkVUq1YtSfw+JxcELiCNCw8PN1/PExcXpwcPHmjYsGH6+++/9d1335kHzJCkS5cuydnZWfb29uZuCnyZAwCQ9LZs2aJFixZJkj7//HNVrVpVkhQVFaWVK1dq4cKFcnd317Rp05QpU6ZEz+f3OflgKwBp2ObNm/X1119r48aNkh4NE5sxY0ZVrVpVR48e1fnz5yU9+tKWpEKFCilXrlzKnj27pEd9wvkyBwAg6WXOnFmnT5/WwYMH9c8//5inOzo66uOPP9ann36qoKAgdejQQaGhoYmez+9z8sGWANKwW7du6e7du+rdu7c6d+6s1atXS5Lq1q2rWrVqafz48bp//36iL+34vuD0CQcAIOk83vGsbNmymj9/vrJly6YVK1aYD4JKkoODgz7++GN98sknunLlivbt22eLcvGc6FIIpBFPuzfW/fv3dfz4cU2ePFlBQUFyc3NTt27ddO3aNW3atElt2rQx9wUHAABJ6/Hf54iICBmNRjk5OZnnHz58WJ06ddLrr7+ufv36ycvLyzwvOjpa/v7+8vb2fuV14/kRuIA04PEv85MnTyooKEh37txRtWrVlDFjRjk6OurevXs6ceKE5s2bp4CAAGXLlk0nTpxQjRo1NHXqVBu/AwAAUp/Hf5/9/Py0fPlyBQUFKVOmTPr8889VpkwZZc2aVYcOHVKXLl1UtGhR9e/f/4k3MuaareSLwAWkIatWrdJ3330nR0dHhYeHm7/Qa9eunWBwjDVr1ujkyZNaunSpunXrpi5dutiwagAAUrf169erb9+++vDDD5UjRw6dP39ex48f1zvvvKOePXvK3d1dR44cUdeuXVWwYEENGDBARYoUsXXZeE4ELiCN2Ldvn7p06aIePXqoXLly8vb21qBBg7R27Vp1795drVu3lsFgkJ2dnfk5N2/eVO7cuSU9vUsiAAB4MY+fjbp7967atWsnHx8fde3aVc7OzpKkcuXKycvLS2PHjjUfFD106JBatmypKVOmqGbNmjarHy+G845AGnHixAkVK1ZMdevWNff1DgoKUs6cOVWlShXZ29snClS5cuWS9OiHgbAFAMDL2bFjh+7evSuj0WgeATg8PFw3btzQm2++aQ5bnTp1kqOjo/r27aucOXMqMDBQDx8+VJkyZbRr1y7CVgpD4AJSoSeduD59+rTCwsLM98/64osvdPr0aU2ePFmFCxfWkSNHdPz48QTPiQ9Z9AkHAODlbNmyRT179tQPP/yge/fumX9bHR0dZWdnZx7avX379jp79qxmzZqlokWL6uTJk5o6dap5aPjH74OJlIG/ooBU5vGuf5cuXdLFixclScWLF1dUVJT8/f3Vrl07Xbx4UTNnzlSRIkV0//59LVq0SAcPHlRMTIwtywcAIFWqWbOmGjZsqK1bt+qHH37Q3bt3JUnp0qVTrly59Ouvv+rTTz/V+fPnNWvWLBUpUkQxMTE6cuSILly4oMjIyATL42BoysGWAlKRx8PWunXr9OWXX2rRokUKDg5WuXLlFBAQoGbNmuny5cuaM2eOihYtqujoaG3fvl0nTpyQp6en7O3tbfwuAABIXaKioiRJw4YNU+XKlbV9+3Zz6HJ1ddU333yjQ4cO6eDBg+rbt6+8vLwUGhqq9evXa8qUKWrYsKEKFSpk43cBSzFoBpAKrVu3TgMHDlSHDh1UrVo180hGGzdu1JdffqkyZcqoU6dOcnFx0d69ezVjxgx16tRJ7du3t3HlAACkLo8fDD137pyuXr2qESNGyGQyqWHDhmrXrp3c3Ny0Y8cO9ejRQ4ULF5arq6vs7e11/PhxtW7dWh07dky0LKQcBC4glQkICNAXX3yhhg0bqn379nJwcDBPd3R01N9//62vv/5akZGRioiIUJ48edSwYUO1bt1aEvfxAADgZcUHo8cD0tq1azVkyBC99957evDgga5evapLly6pefPm5tB15swZbdu2TWfPnlXx4sVVuHBh1ahRQxK/zykZfYeAVObhw4d68OCBSpYsKQcHB929e1fDhw/XyZMndePGDX355ZdasWKF7t27p8jISGXJksU83Cxf5gAAvLzz58+rSJEi5rD1999/a8KECWrRooW6d+8uJycnSZKvr6/Wr18vSWrXrp1ef/11FS1aNNFZLH6fUzYCF5DKuLi4KCwsTMuXL9fGjRt18OBBGQwGNW/eXA8ePNCECRPk6emp6tWrJ3ieyWTiyxwAgJc0Z84crVu3TgsWLFDmzJllMBgUHh6ukJAQlS5dWk5OToqOjpaDg4NGjx6tzp07a8GCBTIajWrbtq3c3NwSLZPf55SNrQekMu7u7po+fbrOnTunW7duqUqVKtq0aZPatGmjunXrKleuXE/84qZPOAAAL6927doaNWqUsmTJoqCgIEmPfpuNRqNOnz4tSXJwcDAPpDFo0CBlzpxZmzZt0qRJkxKNRoiUjzNcQCpUvnx5/fLLL3J0dDRfw/Xw4UOdPHlSkpQlSxZblgcAQKqVJ08eSdLBgwfVu3dvDRgwQLVq1VLt2rW1ZcsWlShRQtWqVZOjo6MkKSgoSJkyZZKHh4f5DBhSFwIXkEplyJDB/O8TJ07o1KlT+u6779S5c2e98cYbtisMAIA0IEeOHMqZM6cmTpwoNzc3devWTW3bttWcOXMUGhqqRo0aKTQ0VBcvXpSnp6fGjBmjTJky2bpsWAGjFAKpXEBAgPr06aM7d+7ok08+MY9GyNCyAABYV0BAgPr166e///5bEydOVPr06TVo0CCdP39euXPnlrOzs06dOqVu3bqpQ4cOkvh9To0IXEAqFxsbq9OnTys6OlpvvfWWJEY7AgDgVbl+/br69eunW7duafz48SpQoIC2bdumjRs3Knv27CpdurQaN24sibCVWhG4gDSGL3MAAF6tx0PXsGHD9M477yT6PeZgaOrFVgXSGMIWAACvVt68eTVy5Eh5eHioX79+2rx5c6LfY8JW6sWWBQAAAKwsb968Gjp0qNzc3BQeHm7rcvAK0aUQAAAAeEVCQ0MZjTCNIXABAAAArxjXVKcddCkEAAAAXjHCVtpB4AIAAAAAKyFwAQAAAICVELgAAAAAwEoIXAAAAABgJQQuAAAAALASAhcAAAAAWAmBCwBgkWrVqsnX19dmr+/r66tq1aolmBYeHq7+/furQoUK8vb21rfffqsbN27I29tbq1evfuU1tmrVSq1atXrlrwsASD7sbV0AACB5uX79uubMmaO9e/fq9u3bcnBwkJeXl+rWraumTZsqXbp0ti7xqX744QetWbNGnTt3Vp48eeTp6Wn117x06ZJ+++03ffDBB/Lw8LD66z1LtWrVdPPmzWe2GzVqlBo3bvwKKgKAtI3ABQAw27Fjh3r06CFHR0c1atRIXl5eio6O1uHDh/Xdd9/p0qVLGj58uK3LlCQNHz5cJpMpwbT9+/erVKlS6tq1q3mayWTSiRMnZG9vnZ+8S5cuaerUqXr77bcTBa65c+da5TX/S79+/RQeHm5+vGvXLv3666/q27evsmTJYp7+5ptvvvLaAPxfe3cfU2X5P3D8jSTFCaEkCBQFQw8iaPLkAywRU0lQD8jsaAc0pyWayNjaJNGZy4fpKGflJokzhclgQ8WjCIjIMlmOFanTIeUDTy7iQQcEgsL9/cNxr9NBfz780JLPa2M71+f63Pd9XfAH++y6rvuI/kgKLiGEEABUV1eTkJDAkCFD2L9/P46OjmqfwWCgsrKS4uLi5zfAfxg4cKBZrLGxkZEjR5rELCwsePnll5/VsExYWVk982dOnz7dpN3Q0MCxY8eYPn36v2IFTggh+hs5wyWEEAKA1NRU2tra2Lx5s0mx1cPV1ZXFixc/8Prbt2+zbds25syZg4+PD76+vixbtozy8nKz3LS0NMLDw3n77bcJCAhg3rx5GI1Gtb+1tZXNmzczbdo0vL29mTx5MkuWLOHSpUtqzt/PcJ07dw4PDw9qamooLi7Gw8NDbT/oDNfVq1eJj49n0qRJjBs3jtDQUHbs2KH219bW8vnnnxMaGsq4ceOYOHEiq1evpqamRs05dOgQ8fHxACxatEh97rlz54Dez3A1Njaydu1aAgMDGTt2LHPnzuXw4cMmOT1j3rt3L5mZmUyfPh1vb2+ioqK4cOHCA/8Gj+Lrr7/Gy8uLpqYms77169fj7+9PR0cHcH974vLly/nxxx/R6XSMHTuWsLAwCgoKzK5tbm5m8+bNBAcH4+3tzYwZM/juu+/o7u5+qvEKIcR/naxwCSGEAOD06dMMGzbsibeaVVdXU1hYyHvvvYeLiwsNDQ1kZmYSHR3N8ePHefPNNwHIyspi06ZNhIaGsmjRIjo6Orhy5Qrnz59nzpw5AGzYsIH8/Hyio6Nxd3fn9u3b/Pzzz1y9ehUvLy+zZ7u7u7N9+3a2bt2Kk5MTS5YsAWDw4MG9Fhbl5eUYDAZeeukl9Ho9Q4cOpaqqiqKiIhISEgC4ePEiZWVlhIeH4+TkRG1tLRkZGSxatIjjx49jbW1NQEAAMTExpKWlERsby1tvvaWOpzd37twhJiaGqqoqDAYDLi4u5OXlkZiYSHNzs1lBe+zYMf766y/0ej0WFhakpqYSFxdHYWFhryt8j0Kn07Fr1y5yc3OJjo5W452dneTn5zNz5kyTFcEbN26QkJDAggULiIyMJDs7m/j4eFJTUwkKCgKgvb2d6Oho6urqWLBgAc7OzpSVlfHVV19RX19PUlLSE41VCCFeCIoQQoh+r6WlRdFqtcqKFSse+ZqQkBBlzZo1arujo0Pp6uoyyamurla8vb2Vb7/9Vo2tWLFCCQ8Pf+i9/fz8lI0bNz40Z82aNUpISIjZmD7++GOzMWi1WiU7O1uNGQwGxcfHR6mtrTXJ7e7uVj+3t7ebPbOsrEzRarXK4cOH1diJEycUrVar/PTTT2b50dHRSnR0tNr+/vvvFa1Wq+Tk5Kixzs5ORa/XK+PHj1daWlpMxjxhwgTl9u3bam5hYaGi1WqVoqKiXn8nvUlNTVW0Wq1SXV2txvR6vTJ//nyTvIKCArN5hISEKFqtVsnPz1djLS0tSlBQkBIREaHGdu3apYwfP165fv26yT2Tk5MVT09P5ebNm488XiGEeNHIlkIhhBC0trYC8Oqrrz7xPaysrBgw4P6/la6uLm7duoVGo2HEiBFcvnxZzbO1teWPP/546NY4W1tbzp8/T11d3ROP50GampooLS0lKiqKIUOGmPRZWFion//+Nsa7d+9y69Ythg8fjq2trcl8HscPP/yAg4MDs2fPVmMDBw4kJiaGtrY2SktLTfLDwsKws7NT2/7+/sD91cSnodPpOH/+PFVVVWrMaDTi7OzMhAkTTHIdHR2ZMWOG2raxsSEiIoLLly9TX18PQF5eHn5+ftja2tLU1KT+BAYG0tXVZTYvIYToT2RLoRBCCGxsbABM3m73uLq7uzlw4AAHDx6kpqaGrq4ute+1115TP3/00UeUlJQwf/58XF1dCQoKYvbs2fj5+ak5n376KYmJiUydOhUvLy+Cg4OJiIhg2LBhTzy+Hj3FilarfWjenTt3SElJ4dChQ9TV1Zm8EbGlpeWJnl1bW4urq6tamPbo2YJ48+ZNk7izs7NJu6f4am5ufqLn9wgLC2PLli0cPXqUVatW0dLSwunTp/nwww9Nik64f3bvnzE3Nzd1Pg4ODlRWVnLlyhUmT57c6/N629YphBD9hRRcQgghsLGxwdHRkd9+++2J77F792527txJVFQU8fHx2NnZMWDAALZs2WJSrLi7u5OXl0dxcTFnzpyhoKCAgwcP8sknn7B69WrgfkHg7+/PyZMnOXv2LHv37mXPnj188803BAcHP/V8H8UXX3zBoUOHWLx4MePHj2fQoEFYWFiQkJBg9jr6vmJpadlr/Gmfb2dnR0hICEajkVWrVpGXl0dnZydz5859ovt1d3cTFBTEsmXLeu3vKdCEEKI/koJLCCEEACEhIWRmZlJWVoaPj89jX5+fn8/EiRPZsmWLSby5udnk+58ANBoNYWFhhIWF0dnZSVxcHLt372b58uXqCxscHR0xGAwYDAYaGxuJjIxk9+7dT11w9aySVVRU/J/ziYiIIDExUY11dHSYrW79c/XnYYYOHcqVK1fo7u42WeW6du0agNkWx76k0+lYuXIlFy5cwGg0MmbMGEaNGmWWV1lZiaIoJvO8ceMGcH8+AMOHD6etrY3AwMBnMnYhhPgvkTNcQgghAFi2bBkajYZ169bR0NBg1l9VVcX+/fsfeL2lpaXZysuJEyfMzmHdunXLpG1lZYW7uzuKonD37l26urrMihp7e3scHR3p7Ox83GmZGTx4MAEBAWRnZ5tt4fv7+HtbXUpLSzPZKglgbW0NPNo2wylTplBfX09ubq4au3fvHmlpaWg0GgICAh5rLk9jypQpvP7666SmplJaWvrA1a0///yTkydPqu3W1laOHDmCp6cnDg4OAMyaNYuysjLOnDljdn1zczP37t3rm0kIIcR/gKxwCSGEAO6vUiQnJ5OQkEBYWBg6nQ6tVktnZydlZWXk5eUxb968B14/depUdu3axWeffYaPjw8VFRUYjUazc1dLly7ljTfewNfXF3t7e65du0Z6ejrBwcHY2NjQ3NxMcHAwoaGhjB49Go1GQ0lJCRcvXjRZbXoa69atY+HChURGRqLX63FxcaG2tpbi4mJycnLU+eTk5GBjY8PIkSP59ddfKSkpMTmPBuDp6YmlpSV79uyhpaUFKysrJk2ahL29vdlz9Xo9mZmZJCYmcunSJYYOHUp+fj6//PILa9euVc/SPQsDBw4kPDyc9PR0LC0tCQ8P7zXPzc2NpKQkLl68iL29PdnZ2TQ2NrJ161Y1Z+nSpRQVFREbG0tkZCReXl60t7dTUVFBfn4+p06dYvDgwc9qakII8a8iBZcQQgjVu+++y9GjR9m7dy+nTp0iIyMDKysrPDw8SExM5P3333/gtbGxsbS3t2M0GsnNzWXMmDGkpKTw5ZdfmuTp9XqMRiP79u2jra0NJycnYmJiWLlyJXD/7YALFy7k7NmzFBQUoCgKw4cPZ8OGDXzwwQf/L/McPXo0WVlZ7Ny5k4yMDDo6OhgyZAizZs1Sc5KSkhgwYABGo5GOjg58fX3Zt2+f2TklBwcHNm7cSEpKCklJSXR1dXHgwIFeC65XXnmFtLQ0kpOTOXz4MK2trYwYMYKtW7c+tJjtKzqdjvT0dCZPntzrl13D/YJr/fr1bN++nevXr+Pi4sKOHTt455131Bxra2vS0tJISUkhLy+PI0eOYGNjg5ubG3FxcQwaNOhZTUkIIf51LJRndfJXCCGEEP8q5eXl6HQ6tm3bRkREhFn/tGnTGDVqFCkpKc9+cEII8YKQM1xCCCFEP5WVlYVGo2HmzJnPeyhCCPHCki2FQgghRD9TVFTE77//TlZWFgaDAY1G87yHJIQQLywpuIQQQoh+ZtOmTTQ0NDBlyhTi4uKe93CEEOKFJme4hBBCCCGEEKKPyBkuIYQQQgghhOgjUnAJIYQQQgghRB+RgksIIYQQQggh+ogUXEIIIYQQQgjRR6TgEkIIIYQQQog+IgWXEEIIIYQQQvQRKbiEEEIIIYQQoo9IwSWEEEIIIYQQfeR/NufAJzrHaucAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_distribution(balanced_data_counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Split dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "train_df, test_df = train_test_split(balanced_data, test_size=0.2, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training data sample size:  560\n",
+      "Test data sample size:  140\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Training data sample size: \", train_df[\"id\"].count())\n",
+    "print(\"Test data sample size: \", test_df[\"id\"].count())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Persist this transformed data to BigQuery to simplify the execution graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "train_df.to_gbq(destination_table=f\"{PROJECT_ID}.{DATASET_ID}.toxicity_train_dataset\", if_exists=\"replace\")\n",
+    "test_df.to_gbq(destination_table=f\"{PROJECT_ID}.{DATASET_ID}.toxicity_test_dataset\", if_exists=\"replace\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "train_dataset = bpd.read_gbq(f\"{PROJECT_ID}.{DATASET_ID}.toxicity_train_dataset\")\n",
+    "test_dataset = bpd.read_gbq(f\"{PROJECT_ID}.{DATASET_ID}.toxicity_test_dataset\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure Gemini"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "system_instructions = [\n",
+    "    \"\"\"You are a Responsible AI specialist, and analysis harmful content with the objective of filtering such undesired content from the web via your analysis\"\"\",\n",
+    "    \"\"\"You will respond only 0s or 1s in JSON format to the following fields: \"toxic\", \"severe_toxic\", \"obscene\", \"threat\", \"insult\", \"identity_hate\" \"\"\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response_schema = {\n",
+    "    \"type\": \"OBJECT\",\n",
+    "    \"properties\": {\n",
+    "        \"toxic\": {\"type\": \"INTEGER\"},\n",
+    "        \"severe_toxic\": {\"type\": \"INTEGER\"},\n",
+    "        \"obscene\": {\"type\": \"INTEGER\"},\n",
+    "        \"threat\": {\"type\": \"INTEGER\"},\n",
+    "        \"insult\": {\"type\": \"INTEGER\"},\n",
+    "        \"identity_hate\": {\"type\": \"INTEGER\"}\n",
+    "    },\n",
+    "    \"required\": [\"toxic\", \"severe_toxic\", \"obscene\", \"threat\", \"insult\", \"identity_hate\"],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "prompt = \"\"\"\n",
+    "Your task is to analyze comments from the web and classify if the content is related to the following classifications: \"toxic\", \"severe_toxic\", \"obscene\", \"threat\", \"insult\", \"identity_hate\"\n",
+    "Here is the comment you should analyze and generate the structured response with the classifications: \n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def predict(prompt, model_name):\n",
+    "\n",
+    "    from vertexai.generative_models import GenerativeModel, GenerationConfig, Part, Content, HarmCategory, HarmBlockThreshold\n",
+    "    \n",
+    "    model = GenerativeModel(model_name=model_name, system_instruction=system_instructions)\n",
+    "    \n",
+    "    prompt_content = Content(\n",
+    "        role=\"user\",\n",
+    "        parts=[Part.from_text(prompt)]\n",
+    "    )\n",
+    "\n",
+    "    response = model.generate_content(\n",
+    "        prompt_content,\n",
+    "        generation_config=GenerationConfig(\n",
+    "            max_output_tokens=128, temperature=0.5, response_mime_type=\"application/json\", response_schema=response_schema\n",
+    "        ),\n",
+    "        safety_settings={\n",
+    "                HarmCategory.HARM_CATEGORY_UNSPECIFIED: HarmBlockThreshold.BLOCK_ONLY_HIGH\n",
+    "        }\n",
+    "    )\n",
+    "    \n",
+    "    return response.text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "@bpd.remote_function(\n",
+    "    [str, str],\n",
+    "    str,\n",
+    "    bigquery_connection=CONNECTION_ID,\n",
+    "    packages=[\"google-cloud-aiplatform\"]\n",
+    ")\n",
+    "def generate_predictions(prompt: str, model_name: str) -> str:\n",
+    "    \n",
+    "    prediction = predict(prompt, model_name)\n",
+    "    \n",
+    "    return prediction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run predictions against the test dataset using Gemini (default)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "test_dataset[\"input_prompt\"] = prompt + test_dataset[\"comment_text\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "input_remote_function = test_dataset[[\"input_prompt\"]].assign(model_name=\"gemini-1.5-pro\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "predictions = test_dataset.assign(pred=input_remote_function.apply(generate_predictions, axis=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>comment_text</th>\n",
+       "      <th>toxic</th>\n",
+       "      <th>severe_toxic</th>\n",
+       "      <th>obscene</th>\n",
+       "      <th>threat</th>\n",
+       "      <th>insult</th>\n",
+       "      <th>identity_hate</th>\n",
+       "      <th>input_prompt</th>\n",
+       "      <th>pred</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>663301f1cb4b59e5</td>\n",
+       "      <td>quick thing mate \n",
+       "\n",
+       "Give me a couple of reasons...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 1, \"severe_toxic\": 1, \"obscene\": 0, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>935b9fdece617e51</td>\n",
+       "      <td>\"Rmcsamson refuses to understand that the issu...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5d1c496c1ce34c9b</td>\n",
+       "      <td>Devious little buggers! If only they'd put hal...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 1, \"severe_toxic\": 0, \"obscene\": 0, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2b044e81580d9695</td>\n",
+       "      <td>{{subst:arbcom notice|Military Occupation of G...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>fc61ea68fdd30317</td>\n",
+       "      <td>I suppose you're right, the keyword here with ...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>ef69c4edfb85559c</td>\n",
+       "      <td>guess what ==\n",
+       "\n",
+       "your retarded\n",
+       "\n",
+       "==</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 1, \"severe_toxic\": 0, \"obscene\": 0, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>ab1aed6659d33e75</td>\n",
+       "      <td>\"\n",
+       " Done -Thanks for the correction suggested. ...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>b514481f358dbd40</td>\n",
+       "      <td>Thanks for heads-up!  You are right about the ...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>1307fa21a863c606</td>\n",
+       "      <td>You would understand... \n",
+       "\n",
+       "You would understand...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 1, \"severe_toxic\": 0, \"obscene\": 1, ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>6ae4580294f2d587</td>\n",
+       "      <td>Editing Wikipedia \n",
+       "\n",
+       "Fuck You, you anal rapist</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\": 1, \"severe_toxic\": 1, \"obscene\": 1, ...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>10 rows × 10 columns</p>\n",
+       "</div>[10 rows x 10 columns in total]"
+      ],
+      "text/plain": [
+       "                 id                                       comment_text  toxic  \\\n",
+       "0  663301f1cb4b59e5  quick thing mate \n",
+       "\n",
+       "Give me a couple of reasons...      1   \n",
+       "1  935b9fdece617e51  \"Rmcsamson refuses to understand that the issu...      0   \n",
+       "2  5d1c496c1ce34c9b  Devious little buggers! If only they'd put hal...      0   \n",
+       "3  2b044e81580d9695  {{subst:arbcom notice|Military Occupation of G...      0   \n",
+       "4  fc61ea68fdd30317  I suppose you're right, the keyword here with ...      0   \n",
+       "5  ef69c4edfb85559c                   guess what ==\n",
+       "\n",
+       "your retarded\n",
+       "\n",
+       "==      1   \n",
+       "6  ab1aed6659d33e75  \"\n",
+       " Done -Thanks for the correction suggested. ...      0   \n",
+       "7  b514481f358dbd40  Thanks for heads-up!  You are right about the ...      0   \n",
+       "8  1307fa21a863c606  You would understand... \n",
+       "\n",
+       "You would understand...      1   \n",
+       "9  6ae4580294f2d587      Editing Wikipedia \n",
+       "\n",
+       "Fuck You, you anal rapist      1   \n",
+       "\n",
+       "   severe_toxic  obscene  threat  insult  identity_hate  \\\n",
+       "0             0        0       1       0              0   \n",
+       "1             0        0       0       0              0   \n",
+       "2             0        0       0       0              0   \n",
+       "3             0        0       0       0              0   \n",
+       "4             0        0       0       0              0   \n",
+       "5             0        0       0       1              0   \n",
+       "6             0        0       0       0              0   \n",
+       "7             0        0       0       0              0   \n",
+       "8             0        1       0       1              0   \n",
+       "9             0        1       0       1              0   \n",
+       "\n",
+       "                                        input_prompt  \\\n",
+       "0  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "1  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "2  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "3  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "4  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "5  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "6  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "7  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "8  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "9  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "\n",
+       "                                                pred  \n",
+       "0  {\"toxic\": 1, \"severe_toxic\": 1, \"obscene\": 0, ...  \n",
+       "1  {\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...  \n",
+       "2  {\"toxic\": 1, \"severe_toxic\": 0, \"obscene\": 0, ...  \n",
+       "3  {\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...  \n",
+       "4  {\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...  \n",
+       "5  {\"toxic\": 1, \"severe_toxic\": 0, \"obscene\": 0, ...  \n",
+       "6  {\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...  \n",
+       "7  {\"toxic\": 0, \"severe_toxic\": 0, \"obscene\": 0, ...  \n",
+       "8  {\"toxic\": 1, \"severe_toxic\": 0, \"obscene\": 1, ...  \n",
+       "9  {\"toxic\": 1, \"severe_toxic\": 1, \"obscene\": 1, ...  \n",
+       "\n",
+       "[10 rows x 10 columns]"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Persist this transformed data to BigQuery to simplify the execution graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "predictions.to_gbq(destination_table=f\"{PROJECT_ID}.{DATASET_ID}.toxicity_predictions_raw\", if_exists=\"replace\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "extract_query = f\"CREATE OR REPLACE TABLE {PROJECT_ID}.{DATASET_ID}.toxicity_predictions AS (SELECT *, \" + \"\".join([f\"CAST(JSON_EXTRACT(pred, '$.{col}') AS INT64) AS predicted_{col},\" for col in classification_columns]) + f\" FROM {PROJECT_ID}.{DATASET_ID}.toxicity_predictions_raw)\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%bigquery\n",
+    "$extract_query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "toxicity_predictions = bpd.read_gbq(f\"{PROJECT_ID}.{DATASET_ID}.toxicity_predictions\", use_cache=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evaluate results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def compute_precision_scores(predictions: DataFrame):\n",
+    "\n",
+    "    precision_scores = {}\n",
+    "\n",
+    "    for col in classification_columns:\n",
+    "        \n",
+    "        y_true = predictions[col]\n",
+    "        y_pred = predictions[\"predicted_\" + col]\n",
+    "        \n",
+    "        precision_score = metrics.precision_score(y_true, y_pred, average=None)\n",
+    "        precision_scores[col] = precision_score.to_dict()\n",
+    "    \n",
+    "    return precision_scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "precision_scores = compute_precision_scores(toxicity_predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 129,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'toxic': {0: 0.7916666666666666, 1: 0.9310344827586207},\n",
+       " 'severe_toxic': {0: 0.8939393939393939, 1: 0.3783783783783784},\n",
+       " 'obscene': {0: 0.8679245283018868, 1: 0.9540229885057471},\n",
+       " 'threat': {0: 0.9895833333333334, 1: 0.5909090909090909},\n",
+       " 'insult': {0: 1.0, 1: 0.7981651376146789},\n",
+       " 'identity_hate': {0: 0.9555555555555556, 1: 0.78}}"
+      ]
+     },
+     "execution_count": 129,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "precision_scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def compute_f1_scores(predictions: DataFrame):\n",
+    "\n",
+    "    f1_scores = {}\n",
+    "\n",
+    "    for col in classification_columns:\n",
+    "        \n",
+    "        y_true = predictions[col]\n",
+    "        y_pred = predictions[\"predicted_\" + col]\n",
+    "        \n",
+    "        f1_score = metrics.f1_score(y_true, y_pred, average=None)\n",
+    "        f1_scores[col] = f1_score.to_dict()\n",
+    "    \n",
+    "    return f1_scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f1_scores = compute_f1_scores(toxicity_predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'toxic': {0: 0.7450980392156864, 1: 0.943231441048035},\n",
+       " 'severe_toxic': {0: 0.6900584795321637, 1: 0.5137614678899083},\n",
+       " 'obscene': {0: 0.8932038834951457, 1: 0.9378531073446328},\n",
+       " 'threat': {0: 0.9090909090909092, 1: 0.732394366197183},\n",
+       " 'insult': {0: 0.738095238095238, 1: 0.8877551020408164},\n",
+       " 'identity_hate': {0: 0.9197860962566844, 1: 0.8387096774193548}}"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f1_scores"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finetune Gemini"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Generate a dataset for fine-tuning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def generate_fine_tuning_dataset(df: DataFrame) -> pd.DataFrame:\n",
+    "    \n",
+    "    df[\"input_prompt\"] = prompt + df[\"comment_text\"]\n",
+    "    fine_tuning_dataset = df.to_pandas()\n",
+    "    fine_tuning_dataset['expected_model_output'] = fine_tuning_dataset[classification_columns].apply(lambda row: row.to_json(), axis=1) \n",
+    "    \n",
+    "    return fine_tuning_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fine_tuning_dataset_train = generate_fine_tuning_dataset(train_dataset)\n",
+    "fine_tuning_dataset_val = generate_fine_tuning_dataset(test_dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>comment_text</th>\n",
+       "      <th>toxic</th>\n",
+       "      <th>severe_toxic</th>\n",
+       "      <th>obscene</th>\n",
+       "      <th>threat</th>\n",
+       "      <th>insult</th>\n",
+       "      <th>identity_hate</th>\n",
+       "      <th>input_prompt</th>\n",
+       "      <th>expected_model_output</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1f6d1ad2a942fd1a</td>\n",
+       "      <td>steve irwin \n",
+       "\n",
+       "МљHEY FAGGIT GO RAPE A 7 YEAR OL...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":1,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1bda7cb63838be2d</td>\n",
+       "      <td>HEATHER MALLICK IS SUCH A PIECE OF CANADIAN TR...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>096aa08835d2c1f1</td>\n",
+       "      <td>ADMINS SCREW OFF \n",
+       "\n",
+       "SCREW OFF YOU FUCKING RETAR...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2ba67d26e5f63509</td>\n",
+       "      <td>bitch why are you deleting my shit.</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>65bd67fef6fcbcc5</td>\n",
+       "      <td>I am going to shoot you in the head and laugh ...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>555</th>\n",
+       "      <td>12c89af929168f6d</td>\n",
+       "      <td>Hey nigger \n",
+       "\n",
+       "Go fuck yourself and stop reverin...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>556</th>\n",
+       "      <td>f5402ab57eb8aeb8</td>\n",
+       "      <td>Jew supremacist liar. 146.179.213.55</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>557</th>\n",
+       "      <td>ef6ecce9bd8b9356</td>\n",
+       "      <td>(they are both wortheless pieces of shit that ...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":0,\"obscene\":1,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>558</th>\n",
+       "      <td>29bb05ac7ee4b466</td>\n",
+       "      <td>poopoo caca bullpenis shit cock mother fucker ...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>559</th>\n",
+       "      <td>8273a778e21ebe18</td>\n",
+       "      <td>Sitush you are an ass.  I do not know who let ...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":0,\"obscene\":1,\"threa...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>560 rows × 10 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   id                                       comment_text  \\\n",
+       "0    1f6d1ad2a942fd1a  steve irwin \n",
+       "\n",
+       "МљHEY FAGGIT GO RAPE A 7 YEAR OL...   \n",
+       "1    1bda7cb63838be2d  HEATHER MALLICK IS SUCH A PIECE OF CANADIAN TR...   \n",
+       "2    096aa08835d2c1f1  ADMINS SCREW OFF \n",
+       "\n",
+       "SCREW OFF YOU FUCKING RETAR...   \n",
+       "3    2ba67d26e5f63509                bitch why are you deleting my shit.   \n",
+       "4    65bd67fef6fcbcc5  I am going to shoot you in the head and laugh ...   \n",
+       "..                ...                                                ...   \n",
+       "555  12c89af929168f6d  Hey nigger \n",
+       "\n",
+       "Go fuck yourself and stop reverin...   \n",
+       "556  f5402ab57eb8aeb8               Jew supremacist liar. 146.179.213.55   \n",
+       "557  ef6ecce9bd8b9356  (they are both wortheless pieces of shit that ...   \n",
+       "558  29bb05ac7ee4b466  poopoo caca bullpenis shit cock mother fucker ...   \n",
+       "559  8273a778e21ebe18  Sitush you are an ass.  I do not know who let ...   \n",
+       "\n",
+       "     toxic  severe_toxic  obscene  threat  insult  identity_hate  \\\n",
+       "0        1             1        0       0       0              0   \n",
+       "1        1             0        0       0       1              1   \n",
+       "2        1             1        1       0       1              0   \n",
+       "3        1             1        1       0       1              0   \n",
+       "4        1             0        0       1       0              0   \n",
+       "..     ...           ...      ...     ...     ...            ...   \n",
+       "555      1             1        1       0       1              1   \n",
+       "556      1             0        0       0       0              1   \n",
+       "557      1             0        1       0       1              1   \n",
+       "558      1             1        1       0       1              0   \n",
+       "559      1             0        1       0       1              0   \n",
+       "\n",
+       "                                          input_prompt  \\\n",
+       "0    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "1    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "2    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "3    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "4    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "..                                                 ...   \n",
+       "555  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "556  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "557  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "558  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "559  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "\n",
+       "                                 expected_model_output  \n",
+       "0    {\"toxic\":1,\"severe_toxic\":1,\"obscene\":0,\"threa...  \n",
+       "1    {\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "2    {\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...  \n",
+       "3    {\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...  \n",
+       "4    {\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "..                                                 ...  \n",
+       "555  {\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...  \n",
+       "556  {\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "557  {\"toxic\":1,\"severe_toxic\":0,\"obscene\":1,\"threa...  \n",
+       "558  {\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...  \n",
+       "559  {\"toxic\":1,\"severe_toxic\":0,\"obscene\":1,\"threa...  \n",
+       "\n",
+       "[560 rows x 10 columns]"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fine_tuning_dataset_train"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>comment_text</th>\n",
+       "      <th>toxic</th>\n",
+       "      <th>severe_toxic</th>\n",
+       "      <th>obscene</th>\n",
+       "      <th>threat</th>\n",
+       "      <th>insult</th>\n",
+       "      <th>identity_hate</th>\n",
+       "      <th>input_prompt</th>\n",
+       "      <th>expected_model_output</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>663301f1cb4b59e5</td>\n",
+       "      <td>quick thing mate \n",
+       "\n",
+       "Give me a couple of reasons...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>935b9fdece617e51</td>\n",
+       "      <td>\"Rmcsamson refuses to understand that the issu...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5d1c496c1ce34c9b</td>\n",
+       "      <td>Devious little buggers! If only they'd put hal...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2b044e81580d9695</td>\n",
+       "      <td>{{subst:arbcom notice|Military Occupation of G...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>fc61ea68fdd30317</td>\n",
+       "      <td>I suppose you're right, the keyword here with ...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>135</th>\n",
+       "      <td>4c7963eaf9697d35</td>\n",
+       "      <td>JIM WALES MUST DIE!!!!!!!!!!!!  JIM WALES MUST...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":1,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>136</th>\n",
+       "      <td>ebdd8918eaeedd4e</td>\n",
+       "      <td>Deletion discussion about Afif Chaya \n",
+       "Hello, A...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>137</th>\n",
+       "      <td>a9577ad4d2d69c3b</td>\n",
+       "      <td>RUNESCAPE IS GAY, EVERYONE JOIN WORLD OF WARCR...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>138</th>\n",
+       "      <td>40dd3e9c8f051076</td>\n",
+       "      <td>Have edited citation on Kingscote page to show...</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>139</th>\n",
+       "      <td>2ec3d168e418c706</td>\n",
+       "      <td>FUCKAN STOP CHANGON IT OR I AM TWIST OFF YOURE...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Your task is to analyze comments from the web...</td>\n",
+       "      <td>{\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>140 rows × 10 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                   id                                       comment_text  \\\n",
+       "0    663301f1cb4b59e5  quick thing mate \n",
+       "\n",
+       "Give me a couple of reasons...   \n",
+       "1    935b9fdece617e51  \"Rmcsamson refuses to understand that the issu...   \n",
+       "2    5d1c496c1ce34c9b  Devious little buggers! If only they'd put hal...   \n",
+       "3    2b044e81580d9695  {{subst:arbcom notice|Military Occupation of G...   \n",
+       "4    fc61ea68fdd30317  I suppose you're right, the keyword here with ...   \n",
+       "..                ...                                                ...   \n",
+       "135  4c7963eaf9697d35  JIM WALES MUST DIE!!!!!!!!!!!!  JIM WALES MUST...   \n",
+       "136  ebdd8918eaeedd4e  Deletion discussion about Afif Chaya \n",
+       "Hello, A...   \n",
+       "137  a9577ad4d2d69c3b  RUNESCAPE IS GAY, EVERYONE JOIN WORLD OF WARCR...   \n",
+       "138  40dd3e9c8f051076  Have edited citation on Kingscote page to show...   \n",
+       "139  2ec3d168e418c706  FUCKAN STOP CHANGON IT OR I AM TWIST OFF YOURE...   \n",
+       "\n",
+       "     toxic  severe_toxic  obscene  threat  insult  identity_hate  \\\n",
+       "0        1             0        0       1       0              0   \n",
+       "1        0             0        0       0       0              0   \n",
+       "2        0             0        0       0       0              0   \n",
+       "3        0             0        0       0       0              0   \n",
+       "4        0             0        0       0       0              0   \n",
+       "..     ...           ...      ...     ...     ...            ...   \n",
+       "135      1             1        0       1       0              0   \n",
+       "136      0             0        0       0       0              0   \n",
+       "137      1             0        0       0       1              0   \n",
+       "138      0             0        0       0       0              0   \n",
+       "139      1             1        1       0       1              0   \n",
+       "\n",
+       "                                          input_prompt  \\\n",
+       "0    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "1    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "2    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "3    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "4    \n",
+       "Your task is to analyze comments from the web...   \n",
+       "..                                                 ...   \n",
+       "135  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "136  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "137  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "138  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "139  \n",
+       "Your task is to analyze comments from the web...   \n",
+       "\n",
+       "                                 expected_model_output  \n",
+       "0    {\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "1    {\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "2    {\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "3    {\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "4    {\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "..                                                 ...  \n",
+       "135  {\"toxic\":1,\"severe_toxic\":1,\"obscene\":0,\"threa...  \n",
+       "136  {\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "137  {\"toxic\":1,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "138  {\"toxic\":0,\"severe_toxic\":0,\"obscene\":0,\"threa...  \n",
+       "139  {\"toxic\":1,\"severe_toxic\":1,\"obscene\":1,\"threa...  \n",
+       "\n",
+       "[140 rows x 10 columns]"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fine_tuning_dataset_val"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def generate_records(df: pd.DataFrame, system_instructions: List) -> List:\n",
+    "    \n",
+    "    records = []\n",
+    "\n",
+    "    for index, row in df.iterrows():\n",
+    "\n",
+    "        input_prompt = row['input_prompt']\n",
+    "        expected_model_output = row['expected_model_output']\n",
+    "\n",
+    "        record = {\n",
+    "          \"systemInstruction\": {\n",
+    "            \"role\": \"system\",\n",
+    "            \"parts\": [ { \"text\": system_instruction } for system_instruction in system_instructions ]\n",
+    "          },\n",
+    "          \"contents\": [\n",
+    "            { \"role\": \"user\", \"parts\": [ { \"text\": input_prompt } ] },\n",
+    "            { \"role\": \"model\", \"parts\": [ { \"text\": expected_model_output } ] } ] \n",
+    "        }\n",
+    "\n",
+    "        records.append(record)\n",
+    "        \n",
+    "    return records"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "train_records = generate_records(fine_tuning_dataset_train, system_instructions)\n",
+    "val_records = generate_records(fine_tuning_dataset_val, system_instructions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fine-tuning train dataset size:  560\n",
+      "Fine-tuning validation dataset size:  140\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Fine-tuning train dataset size: \", len(train_records))\n",
+    "print(\"Fine-tuning validation dataset size: \", len(val_records))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Upload to GCS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME = \"<YOUR_BUCKET_NAME>\"\n",
+    "\n",
+    "TRAIN_FILE_NAME = \"fine-tuning-train-dataset.jsonl\"\n",
+    "VAL_FILE_NAME = \"fine-tuning-val-dataset.jsonl\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def upload_gcs(records: List, file_name: str, bucket_name: str = BUCKET_NAME, project_id: str = PROJECT_ID) -> str:\n",
+    "    \n",
+    "    storage_client = storage.Client(project=project_id)\n",
+    "    bucket = storage_client.bucket(bucket_name)\n",
+    "    blob = bucket.blob(file_name)\n",
+    "\n",
+    "    jsonl_data = \"\\n\".join(json.dumps(item) for item in records)\n",
+    "    blob.upload_from_string(jsonl_data)\n",
+    "    \n",
+    "    uri = f\"gs://{bucket_name}/{file_name}\"\n",
+    "\n",
+    "    return uri"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "uri_train = upload_gcs(train_records, TRAIN_FILE_NAME)\n",
+    "uri_val = upload_gcs(val_records, VAL_FILE_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run Vertex AI Supervised Fine Tuning job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import vertexai\n",
+    "from vertexai.tuning import sft\n",
+    "\n",
+    "vertexai.init(project=PROJECT_ID, location=\"us-central1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "sft_tuning_job = sft.train(\n",
+    "    source_model = \"gemini-1.5-pro-002\",\n",
+    "    train_dataset = uri_train,\n",
+    "    validation_dataset = uri_val,\n",
+    "    epochs = 8,\n",
+    "    adapter_size = 4,\n",
+    "    learning_rate_multiplier = 0.8,\n",
+    "    tuned_model_display_name = \"tuned_gemini_1_5_pro\",\n",
+    ")\n",
+    "\n",
+    "while not sft_tuning_job.has_ended:\n",
+    "    time.sleep(60)\n",
+    "    sft_tuning_job.refresh()\n",
+    "\n",
+    "print(sft_tuning_job.tuned_model_name)\n",
+    "print(sft_tuning_job.tuned_model_endpoint_name)\n",
+    "print(sft_tuning_job.experiment)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Fx4lsNqMorJ-"
+   },
+   "source": [
+    "## Run predictions against the test dataset using Gemini (fine-tuned)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "input_remote_function_tuned = test_dataset[[\"input_prompt\"]].assign(model_name=sft_tuning_job.tuned_model_endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "predictions_tuned = test_dataset.assign(pred=input_remote_function_tuned.apply(generate_predictions, axis=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "predictions_tuned.to_gbq(destination_table=f\"{PROJECT_ID}.{DATASET_ID}.toxicity_predictions_finetuned_raw\", if_exists=\"replace\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "extract_query = f\"CREATE OR REPLACE TABLE {PROJECT_ID}.{DATASET_ID}.toxicity_predictions_finetuned AS (SELECT *, \" + \"\".join([f\"CAST(JSON_EXTRACT(pred, '$.{col}') AS INT64) AS predicted_{col},\" for col in classification_columns]) + f\" FROM {PROJECT_ID}.{DATASET_ID}.toxicity_predictions_finetuned_raw)\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%bigquery\n",
+    "$extract_query"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "toxicity_predictions_tuned = bpd.read_gbq(f\"{PROJECT_ID}.{DATASET_ID}.toxicity_predictions_finetuned\", use_cache=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evaluate results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "precision_scores_tuned = compute_precision_scores(toxicity_predictions_tuned)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 131,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'toxic': {0: 0.7692307692307693, 1: 0.9385964912280702},\n",
+       " 'severe_toxic': {0: 0.8018867924528302, 1: 0.4117647058823529},\n",
+       " 'obscene': {0: 0.8846153846153846, 1: 0.9545454545454546},\n",
+       " 'threat': {0: 0.98989898989899, 1: 0.6341463414634146},\n",
+       " 'insult': {0: 0.8571428571428571, 1: 0.8791208791208791},\n",
+       " 'identity_hate': {0: 0.9354838709677419, 1: 0.7872340425531915}}"
+      ]
+     },
+     "execution_count": 131,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "precision_scores_tuned"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "f1_scores_tuned = compute_f1_scores(toxicity_predictions_tuned)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'toxic': {0: 0.7547169811320754, 1: 0.9427312775330398},\n",
+       " 'severe_toxic': {0: 0.8056872037914692, 1: 0.40579710144927533},\n",
+       " 'obscene': {0: 0.9019607843137256, 1: 0.9438202247191012},\n",
+       " 'threat': {0: 0.9245283018867925, 1: 0.7647058823529412},\n",
+       " 'insult': {0: 0.8235294117647058, 1: 0.898876404494382},\n",
+       " 'identity_hate': {0: 0.9157894736842105, 1: 0.8222222222222222}}"
+      ]
+     },
+     "execution_count": 112,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f1_scores_tuned"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prediction results difference between Gemini vs Gemini Fine Tuned"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def plot_differences(title, gemini_scores, gemini_finetuned_scores):\n",
+    "    \n",
+    "    categories = list(gemini_scores.keys())\n",
+    "    \n",
+    "    gemini_scores = [np.mean(list(v.values())) for v in gemini_scores.values()]\n",
+    "    gemini_finetuned_scores = [np.mean(list(v.values())) for v in gemini_finetuned_scores.values()]\n",
+    "\n",
+    "    differences = [m1 - m2 for m1, m2 in zip(gemini_scores, gemini_finetuned_scores)] \n",
+    "\n",
+    "    bar_width = 0.35\n",
+    "    index = np.arange(len(categories))\n",
+    "\n",
+    "    fig, ax = plt.subplots()\n",
+    "    rects1 = ax.bar(index, gemini_scores, bar_width, label='Gemini')\n",
+    "    rects2 = ax.bar(index + bar_width, gemini_finetuned_scores, bar_width, label='Gemini Fine Tuned')\n",
+    "\n",
+    "    ax.set_xlabel('Classification')\n",
+    "    ax.set_ylabel('Score value')\n",
+    "    ax.set_title(title)\n",
+    "    ax.set_xticks(index + bar_width / 2)\n",
+    "    ax.set_xticklabels(categories, rotation=45, ha='right')\n",
+    "    ax.legend()\n",
+    "\n",
+    "    fig.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Precision Score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAm8AAAHPCAYAAAAFwj37AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACEJElEQVR4nO3ddVwU+f8H8NfuAiIgqeIpoqICFnagpygmdmO3omLheSfG2d19duGZX+NMFOuwO7BQscCgpXN3fn/wY44VUECWZfX1fDzuce7sxHs+LMNrPzPzGYkgCAKIiIiISCNI1V0AEREREWUdwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbEWWZu7s7HB0ds7XMjRs3YGNjgxs3bqioqp+Xo6Mj3N3dxdeZtfWRI0fQqlUrVKpUCbVq1RKnb968GU2bNkWFChXQoUOHPKubiL6PlroLIKLMHTp0CJMmTRJf6+jooHjx4mjQoAFGjhyJwoULq7E60gR+fn6YNGkSGjZsiGHDhkFXVxcAcPnyZSxevBjt27fH6NGjYWJiouZKiSirGN6INMCYMWNgYWGBxMRE3LlzB3v27MG///6L48ePo2DBgnlWx+zZs5HdxyHXrl0bDx8+hLa2toqqolQZtfXNmzehUCgwZcoUlCpVSpx+/fp1SKVSzJ07Fzo6Ouool4hyiOGNSAM0atQIVapUAQB069YNxsbG2LZtG86dO4e2bdtmuExsbCz09PRytY6cBDCpVIoCBQrkah2aQhAEJCQkiL1dqpZRW4eGhgIAChUqlG66rq5urga3uLi4PP0yQfSz4jVvRBqoXr16AICAgAAAKdeiVa9eHe/evcPQoUNRvXp1TJgwAQCgUCiwfft2tGnTBlWqVEH9+vUxbdo0REREpFvvv//+iz59+qB69eqoUaMGunTpgmPHjonvZ3TN24kTJ9C5c2dxmXbt2mHHjh3i+5ldh3Xq1Cl07twZdnZ2qFu3LiZMmIDAwECleVL3KzAwECNHjkT16tVRr149LFy4EHK5/Jvt5OPjg8GDB6Nu3bqws7ODo6Oj0mno1PbZsWMH2rVrhypVqqBevXoYPHgwfHx8xHmSk5Oxdu1aNGvWDJUrV4ajoyOWLVuGxMREpXU5OjrCxcUFly5dEvdt7969AIDIyEjMnTsXDg4OqFy5Mpo3b46NGzdCoVB8cz8EQcC6devQqFEjVK1aFX379sWLFy/SzfdlWzs6OmL16tUAAHt7e9jY2GD16tWwsbHBoUOHEBsbCxsbG/F1qn/++Uesv06dOnBzc8PHjx+VttW3b1+0bdsWjx49Qu/evVG1alUsW7YMAJCYmIhVq1ahefPmqFy5MhwcHLBo0aJ07WVjY4NZs2bh7NmzaNu2LSpXrow2bdrA29s73b4FBgZi8uTJ+PXXX8WfwfTp05XWmdU2/tZnlii/Y88bkQZ69+4dAMDY2FiclpycjMGDB6NmzZqYOHGi2Nszbdo0HD58GJ07d0bfvn0REBCAv//+G0+ePMGePXvE3rRDhw5h8uTJKF++PFxcXFCoUCE8ffoUly5dQrt27TKs48qVKxg/fjzs7e3FsPjq1SvcvXsX/fv3z7T+1Gv5qlSpgvHjxyM0NBQ7d+7E3bt3ceTIERgaGorzyuVyDB48GHZ2dvjjjz9w7do1bN26FSVLlkSvXr0y3UZoaCgGDx4MExMTDBs2DIaGhggICICXl5fSfFOmTMGhQ4fQqFEjdO3aFXK5HLdv38aDBw/E3s6pU6fi8OHDaNmyJQYOHIiHDx9iw4YN8PPzw9q1a5XW9/r1a/z2229wdnZG9+7dUaZMGcTFxaFPnz4IDAxEjx498Msvv+DevXtYtmwZgoODMWXKlEz3AwBWrlyJv/76Cw4ODnBwcMDjx48xaNAgJCUlfXW5yZMn48iRI/Dy8sKMGTOgp6cHGxsbWFpaYv/+/Xj48CHmzJkDAKhRowYA4K+//sLKlSvh5OSErl27IiwsDLt27ULv3r3T/Ww+f/6MoUOHok2bNmjfvj3MzMygUCgwYsQI3LlzB927d0fZsmXx/Plz7NixA2/evMG6deuUarxz5w7OnDmDXr16QV9fHx4eHhgzZgwuXLggXocXGBiIrl27IioqCt27d4eVlRUCAwNx+vRpxMfHQ0dHJ8ttnNPPLFG+IhBRvnXw4EHB2tpauHr1qhAaGip8/PhROHHihFCnTh3Bzs5O+PTpkyAIgjBx4kTB2tpaWLJkidLyt27dEqytrYWjR48qTff29laaHhkZKVSvXl3o1q2bEB8frzSvQqEQ/z1x4kShSZMm4us5c+YINWrUEJKTkzPdh+vXrwvW1tbC9evXBUEQhMTERMHe3l5o27at0rYuXLggWFtbCytXrlTanrW1tbBmzRqldXbs2FHo1KlT5g0nCIKXl5dgbW0tPHz4MNN5rl27JlhbWwuzZ89O917qfj99+lSwtrYWpkyZovT+ggULBGtra+HatWvitCZNmgjW1taCt7e30rxr164VqlWrJrx+/Vpp+pIlS4QKFSoIHz58yLTG0NBQoVKlSsKwYcOUfhbLli0TrK2thYkTJ4rTvmxrQRCEVatWCdbW1kJoaKjSeidOnChUq1ZNaVpAQIBQoUIF4a+//lKa7uvrK1SsWFFpep8+fQRra2thz549SvMeOXJEsLW1FW7duqU0fc+ePYK1tbVw584dcZq1tbVQqVIl4e3bt+K01Pb28PAQp/3xxx+Cra1thj/L1DbJahtn5TNLlN/xtCmRBhgwYADs7e3h4OAANzc36OvrY82aNTA3N1ear2fPnkqvPT09UahQITRo0ABhYWHif5UqVYKenp54eu3KlSuIiYnBsGHD0l0zJZFIMq3L0NAQcXFxuHLlSpb35dGjRwgNDUXPnj2VttW4cWNYWVnh4sWL6Zb5cr9q1qwpnjLOTOo1XhcvXsy0h+rMmTOQSCQYNWpUuvdS9/vff/8FAAwcOFDp/UGDBim9n8rCwgINGzZUmubp6YmaNWvC0NBQ6edQv359yOVy3Lp1K9P9uHr1KpKSktCnTx+ln4Uqeom8vLygUCjg5OSkVGfhwoVRqlSpdKe+dXR00LlzZ6Vpnp6eKFu2LKysrJTWkXqq/8t11K9fH5aWluJrW1tbGBgYwN/fH0DKae2zZ8+iSZMmYk9oWqltktU2zslnlii/4WlTIg0wbdo0lClTBjKZDIULF0aZMmUglSp/99LS0kKxYsWUpr19+xZRUVGwt7fPcL2pF7OnnoYtX758turq1asXTp06haFDh8Lc3BwNGjSAk5MTGjVqlOkyHz58AACUKVMm3XtWVla4c+eO0rQCBQrA1NRUaZqRkVGG1+ylVadOHbRs2RJr1qzB9u3bUadOHTRr1gzt2rUTL9J/9+4dihYtqnT6+Uvv37+HVCpVChgAUKRIERgaGuL9+/dK0y0sLNKt4+3bt/D19c305xAWFpbp9lPbq3Tp0krTTU1NYWRklOlyOfHmzRsIgoAWLVpk+L6WlvKfDHNz83Q3PLx9+xZ+fn7f/Myl+uWXX9LNY2RkhMjISAApbRMdHf3Nz2ZW2zgnn1mi/IbhjUgD2NnZZdjrkJaOjk66QKdQKGBmZoYlS5ZkuMyXoSi7zMzMcOTIEVy+fBne3t7w9vbGoUOH0LFjRyxcuPC71p1KJpPlaDmJRIJVq1bh/v37uHDhAi5duoTJkydj27Zt2LdvH/T19bO9vqzI6M5ShUKBBg0aYMiQIRku82UwUxeFQgGJRIJNmzZl2O5f3r2c2b5aW1unuzEk1ZdfMDL7+QrZHJImq22cF59ZIlVjeCP6gVlaWuLatWuoUaPGV4erSO1VevHihdJYYFmho6MDR0dHODo6QqFQYMaMGdi3bx9GjhyZ4bqKFy8OIOXC/i97SV6/fi2+n1uqVauGatWqwc3NDceOHcOECRNw8uRJdOvWDZaWlrh8+TI+f/6cae9biRIloFAo8PbtW5QtW1acHhISgsjISJQoUeKbNVhaWiI2Nhb169fPdv2p7fHmzRuULFlSnB4WFvbN3sfssrS0hCAIsLCwyLBnNKvrePbsGezt7bMceL/G1NQUBgYGGd5d++V2s9rG2f3MEuU3vOaN6Afm5OQEuVye7g4/IOXu1NRTU7/++iv09fWxYcMGJCQkKM33tR6Q8PBwpddSqRQ2NjYAkG5YiFSVK1eGmZkZ9u7dqzTPv//+Cz8/PzRu3DhL+/YtERER6WqvUKGCUm0tWrSAIAhYs2ZNuuVTl3VwcACAdENJbNu2Ten9r3FycsK9e/dw6dKldO9FRkYiOTk502Xr168PbW1t7Nq1S2l/VDG0RYsWLSCTybBmzZp0bScIQrqfd0acnJwQGBiI/fv3p3svPj4esbGx2apJKpWiWbNmuHDhgtLwLWnrSt1uVto4J59ZovyGPW9EP7A6derA2dkZGzZswNOnT9GgQQNoa2vjzZs38PT0xJQpU9CqVSsYGBhg0qRJmDp1Krp27Yq2bdvC0NAQz549Q3x8fKank6ZOnYqIiAjUq1cP5ubm+PDhA3bt2oUKFSoo9VKlpa2tjQkTJmDSpEno06cP2rRpIw4VUqJECQwYMCBX9v3w4cPYs2cPmjVrBktLS8TExGD//v0wMDAQr2+qV68eOnToAA8PD7x9+xYNGzaEQqHAnTt3ULduXfTp0we2trbo1KkT9u3bh8jISNSuXRs+Pj44fPgwmjVrJl6I/zWDBw/G+fPnMXz4cHTq1AmVKlVCXFwcnj9/jtOnT+PcuXOZnsI2NTXFoEGDsGHDBri4uMDBwQFPnjyBt7d3rj/SytLSEuPGjcPSpUvx/v17NGvWDPr6+ggICMDZs2fRvXt3DB48+Kvr6NChA06dOoXp06fjxo0bqFGjBuRyOV69egVPT09s3rz5m5cAfGn8+PG4cuUK+vbtKw4/EhwcDE9PT+zevRuGhoZZbuOcfGaJ8huGN6If3KxZs1C5cmXs3bsXy5cvh0wmQ4kSJdC+fXtxbC8g5ckNZmZm2LhxI9atWwctLS1YWVl9NUy1b98e+/fvx+7duxEZGYkiRYrAyckJo0ePTnf9XVqdO3eGrq4uNm3ahCVLlkBPTw/NmjXD77//rjSO2PeoU6cOfHx8cPLkSYSEhKBQoUKws7PDkiVLlE4/zp8/HzY2Nvjf//6HRYsWoVChQqhcuTKqV68uzjNnzhxYWFjg8OHDOHv2LAoXLgwXF5cM71LNSMGCBeHh4YENGzbA09MTR44cgYGBAUqXLo3Ro0ene/rBl8aNGwcdHR3s3bsXN27cgJ2dHbZu3QoXF5ecNc5XDBs2DKVLl8b27dvFMeyKFSuGBg0apBugOSNSqRRr167F9u3b8c8//8DLywsFCxaEhYUF+vbtm6PTsebm5ti/fz9WrlyJY8eOITo6Gubm5mjUqJF4OUBW2zinn1mi/EQiZPeqUCIiIiJSG37NICIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEE4zttXCIIAheLHHElFKpX8sPumbmxb1WC7qg7bVjXYrqrzo7atVCrJ0mPlGN6+QqEQEBYWo+4ycp2WlhQmJvqIjIxFcrJC3eX8UNi2qsF2VR22rWqwXVXnR25bU1N9yGTfDm88bUpERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoR3m+YChUIBuTxZ3WVkmUIhQXy8DImJCZDLf7xbrdXpZ2tbmUwLUim/AxIR5SWGt+8gCAIiI8MQFxet7lKyLSRECoXix7rFOr/42dq2YEEDGBqaZmlsIiIi+n4Mb98hNbgZGJhAR6eARv3xkskkP0XPkDr8LG0rCAISExMQHR0OADAyMlNzRUREPweGtxxSKORicDMwMFR3OdmmpSX94QY3zC9+prbV0SkAAIiODkehQiY8hUpElAd4pM0huVwO4L8/XkQ/q9TfAU267pOISJMxvH0nTTpVSqQK/B0gIspbDG9EREREGoTXvKmAVCqBVJr3vREKhQCF4se/UJ5+XjKZer5v8neLiPIThrdcJpVKYGysp5Y/MnK5Ap8/x+b4j8y1a1dw8OA+PHv2BFFRUTA0NIKtbQW0aOGEpk1b5MnF6CdPHsO8eTNx/PhZGBsbZ3m5LVs2YO/eXfDyuqS64khtJBIJBIUChoYF1bJ9hVyO8M9xDHBElC8wvOUyqVQCmUyKJX/fQUBgVJ5t18K8ECb0rgmpVJKjPzAbNqyFh8c2NGrUBG5uf8DMrDDCwsJw6dJFzJ49DYaGRqhb1z7X6/6Svf2vWL9+GwwMDLK1XLt2HVG//q8qqoqyQiaTQEtLNQFfS0sKiVSKoCMrkBgaoJJtZEbHzAJFO47L8e8WEVFuY3hTkYDAKPi9j1B3GVly9epleHhsw8CBQzF4sIvSe46OzdCtWw9oaeXNR8XExAQmJibZXq5oUXMULWqugoroSzKZFGnvUVAoJJBKpTAy0oOurq5Kt50YGoDET69Vug0iovyO4Y2wb9/fMDMrjP79B2f4fsWKlZVeX716Gdu2bYKf30vo6RVE48ZN4eo6DgULppzSunv3NsaMGY6lS1fj+PF/cP36FRQqZIjhw0ejRYtWOHBgL/bs8UBcXBwcHJpg/PiJ0NHRAZD+tOnHjx/QrVt7/PnnLDx+7IMzZzxRoIAOmjd3wvDho8RQydOmeUciAT6FxiIpOWW4HEGRhKjIeMzbdhORcaoZ366GbVH0a11RJesmItI0DG8/ueTkZPj4PEDjxk2z1Lt24cJZTJ8+Ga1bt8PgwS4IDQ3B+vVrEBUViZkz5yvNu2TJArRu3Rbt23fE0aNHMGfONLx8+RyvX/vh998n4cOH91i9ejmKFy+Bfv0GfXW7GzeuQ8OGDpg9ez58fB5i69aNsLCwQMeOXb9r/ylnkpLlSEhMCW8QFEiSK+AfFIWQSNWM9WZRNHun0YmIfmQMbz+5yMgIJCYmpjvlKAiCOBAxAEilUkgkEqxduxKOjs3h7v6n+J6ZWWH8/vtY9O8/BFZWZcXpTZo0xcCBQwEAFSpUhrf3BZw9exr79/8jBsV79+7gwoWz3wxvFStWxrhxvwMAateuh7t3b+PChfMMb0T0TeoYAUBdd0bTz4HhjQCkH2j14sVz+PNPd/F1587d0LWrMz59+ogxY35DcvJ/PSzVq9eAVCqFr+9TpfBWu3Zd8d8GBgYwNjZBtWo1lHr4SpYshXv37nyzvjp16im9Ll3aCnfv3sr6DhLRT0mdIwAoFAIHsSaVYHj7yRkaGkFHRwdBQYFK02vWrIPNm3cCACZOHA8A+Pz5MwBg8uQJGa4rMPCT0utChQopvdbW1k53F6mWlhYSExO/WeeXy2lra2dpOSL6ueWHEQCIchvD209OS0sLVapUxZ07tyCXyyGTyQAAhoaGMDRMuUBcW1v7/6cZAQDc3P5ApUqV062rcOEieVQ1EVH2aNIIAETfwpPyBGfn3ggJCYaHx7avzleqVGkULWqODx/ew9a2Yrr/GN6IiIhUjz1vKmJhXujbM+WT7dWv/yv69BmAzZvX48ULXzg6tkDhwoURHR2NBw/uISwsFHp6+pBIJBg1yg0zZ05BfHwc7O1/RcGCBfHp00dcu3YZw4a5wtKyVC7uFREREX2J4S2XKRQC5HIFJvSumefblssVOR4BfvjwUbCzq4ZDh/Zj2bIFiI6OhqGhEWxsbOHuPg3NmrUAkDJob6FCBtixYyvOnDkFAChW7BfUrVsfpqZmubYvRERElDGJIAh83ksm5HIFwsJiMnwvKSkRoaEfYWb2C7S1dZTe04QH02tpSZGcrJoBVX92P3rbamlJ4R8YlWact2RERwVj57lAlY3z5lC9BCb0qYWALRPy/AkLOsXKwGLwEoSHx/yQP1ctLSlMTPR/+P0bt+xinl7zVraEEVaMb4zIyDgkJKjm9+Jn9SN/Zk1N9bN0ZzR73lQgOyGKiIiIKDt4wwIRERGRBmHPGxERkYpIpRJoaalngOC8OAPEp1eoB8MbERFRLjMuVACCQgEDA121bF8hlyP8c5xKAxyfXqE+DG8/oZ/4805ElCcMCmpDIpUi6MgKJIYG5Om2dcwsULTjOEilEpWHN3U+vUJLS4q8vucyv1zTzvCmZjKZVC1hShBSQhzvNSYiUp3E0IA8v0M6r+X10yvU2auZFz2aWcHwpmYSCfApNBZJyfI826a2lgzFzPQASAAwvRERkeZQV69mXvVoZgXDWz6QlCz/b8ysPCCTSgEBkMkkSAlweUcQUsbPIyIi+h4/Q69mZhjefkJSqQSQAEmfAyEkJ+XZdiVa2tA2Ns+z7REREf2IGN5UIDu3TstkUhQsoJUrd+skJyuQmJT1HjwhOQlCUsJ3b5eIiIjyDsNbLpNKJTAxLgipTJblZQwNC+bKtuVyOR49D85WgEvr+p17OHTyFJ69fInomFgYGhjAppwVmjs0gmOD+pBK8+Z28JMnj2HevJk4fvwsjI2Ns7zcli0bsHfvLnh5Xcp0nrt3b2PMmOEZvnf8+FlMnfoH9PT0sGjRimxWnX1du7bDp08fvzrPwIFDMXiwi8pr+ZoXL3wxcGBvrFq1HjVq1FJrLURExPCW66RSCaQymdoupNTSkuYovG3ctRt/HzyMhnXrYNzQwTAzMUHY5whcvnkTc1esgqGBAepUr5b7hWfA3v5XrF+/DQYGBtlarl27jqhf/9cszTt58nRYWpZWmmZgYIDffnPPszGL5s1bjMTE/05bT5kyAVWqVEOPHn3EaUWLFs2TWoiISHMwvKmIJl1Iee32Hfx98DAGOHfDwB7dld5r0sAeXdu0hkwr7z4qJiYmMDExyfZyRYuao2jRrF1TZ2VVFra2FdNNL1PGKtvbzSlra1ul19raOjA1NUXlylXyrAYiItI8fMYEYf/R4zAzMUHfbl0yfL+CdXlYW5VRmnbt9h0M/2MSmjv3Qvv+g7B0/UbExceL79979BgOnbrh5r37mL54GVr17IOuAwfh9OlTAIADB/aic+c2cHJyxIIFs5GYmCgue/LkMfz6ay18/vwZAPDx4wf8+mstnD59EsuWLUSrVk3QoUNLrFmzAsnJyeJyW7ZsQPPmDb+rLUaNGoY//hiXbp1+fi8xYsRgNG3aAH37dseNG9fSLXvy5DH0798DjRrVQ8eOTtiwYS3k8pzfRTx37gz07ascpqOiovDrr7Vw8uQxcVrXru2wbNlCHDy4H126tEXLlg6YNOk3hIeHp1t2yZIF6NChJZo0scegQX1w8+b1dNvdvn0z2rdviebNG2Ly5N/TrYeIiNSL4e0nlyyX49EzX9SoUhlaWbxO7+LVa5g8fyGsSllizsTfMbxfX1y6fhOL1v6Vbt5lGzahjGVJzJ74OyrZ2GDmzD+xbt0q3Lx5Db//PglDhrjA0/ME9u7d9c3tbty4DlKpFLNnz0eHDl2wd+8uHD9+JLu7DCBluJLk5GTxP4Ui8+FLkpOTMWvWVLRu3Q7z5i2BiYkppk79AxERn8V59u7dhYUL56BOHXssXrwCvXv3x//+tw8bN67LUX3ZdfmyN65c8cb48RMxduwE3Lt3FytWLBLfT0pKgpubK65evYShQ0diwYJlKFOmDH7/fSz8/F6K8x08uA+bN69Hy5atMWfOIhQvXgILFszOk30gIqKs4WnTn1xkVBQSk5JQtLCZ0nRBECBPE2ikEgmk0pRHkfy13QNNGtTHH64jxPfNTIwxcc589OvWFWUsS4rTG9e3xwDnbgCAihUrwfvadZw9exr79/8Drf8/FXvv3h1cuHAW/foN+mqtFStWxrhxvwMAateuh7t3b+PChfPo2LFrtvfbxWWA0uu2bTvA3f3PDOdNSkrC8OGjYG+fcj2dpWUpdOvWHtevX0XLlq0RGxuDLVs2olevfnBxcYWWlhQ1a9aBtrYWVq9ejl69+sLIyDjbNWbXggXLoKOjAyClt9LDYxsUCgWkUinOnDmFFy98sX37HvHUcN269vD398f27Zsxe/YCyOVyeHhsR8uWreHqOlacJzw8DKdPn1R5/URElDUMb5Tii2d0/XvtOqYvXia+7uTUEuOGDYH/hw/4FByMUYMHIDnNKcFqlSpCKpHA96WfUnirVdVO/LeBvj5MTExQrVoNMbgBQMmSpXDv3p1vllinTj2l16VLW+Hu3VtZ38c0pk6didKl/zsVbGyc+TV2UqkUtWrVFV//8ktxFChQAEFBQQAAH5+HiIuLRZMmTf//NK4UyckK1KpVFwkJCXj1yg/Vq9fMUZ1ZVa1aDTG4ASltk5ycjPDwMJiZFcbNm9dRtmw5lCxpqXSquXbtujhzJuVUdnBwEEJCgtGoUROldTdp0pThjYgoH2F4+8kZFioEHW1tBIeGKk2vaVcFGxYvAABMnrdQnB4RmfLw4akLFme4vqAv1mOgr6/0WktLO91dpFpaWkrXvGXmy+W0tbWztFxGSpcuk+ENCxkpUKAAtLW1M9h2yhh5qadPBw3q8+WiAICgoMAc1ZgdGbUNALF9IiI+4/lzXzRuXC/dsrL/P10eEhICAOluFjExMUu3DBERqQ/D209OSyZDZVsb3H3oA7lcLv4hL2RgANtyKYFAO00vWaH/Dwnjhg5GBevy6dZX2DT7d4lqukKFDAEAc+cuhrm5OWQyqdIjwH75pXiO1qujo4OkpGSlaVFRkTlal6GhEcqWLY9JkzI+NQwAhQsXBoB0NyiEh4dmNDsREalJvgtvfn5+mDNnDu7duwd9fX106NAB48aNUzollJHw8HAsX74c3t7e+Pz5MywsLNC7d2/07NkzjyrXXN3bt4X73AXYdfAw+nf/+vVjpSxKoIiZGT4EBqJT61Z5VGH+VrmyHXR1dREcHAgHhybQ0ko5bfq9ihQpiuDgQMTGxkJPTw8AMrw7NCtq1aqDa9euoHDhIihcuEim2zMzKwxv7wtwcPjv1OmFC+dytE3SLHk1vmFaCoWg9gd8E2mifBXeIiIi0L9/f5QuXRqrV69GYGAgFixYgPj4eEybNu2ry44dOxavXr3C+PHj8csvv8Db2xszZsyATCZD9+7dv7qsKuiYWWjM9uxr1UTvzh2xdc8+vHz9Bk1+rQ8zExPExMTi4dOnCPv8GXoFU54CIZFI4DqwP2YvX4n4+ATUq1UDBQsUwKfgEFy/cwdDe/dCyRI562nSVIUKFcLgwcOxbt1qBAUFoVat2gAk+PAhAJcueWPu3EXQ1dXN9nodHByxZcsGzJ8/C+3bd8Tr169w7NiRHNXYqlUb/PPPIYwa5YKePfugZElLREdH48ULX/GGDJlMhj59BmDlyiUwNTVD7dp1cfPm9Sxdj0iaSyKRQFAocu1JL9mhkMsR/jmOAY4om/JVeNu7dy9iYmKwZs0a8bFIcrkcM2fOhIuLC8zNMx6ANTg4GDdu3MD8+fPRuXNnAIC9vT18fHxw4sSJPA1vCoUAhVyOoh3H5dk2U8nl8hz3+Azr2xtVKtji8KnTWLFhM6JjUx6PZV3WCn+MGoGmvzYQ523SwB4G+nrY9b9D8PL2BgAUK1IUdWpUg4mxUa7si6bp2bMPihQpgn37/sbBg/uhpSVDiRIWqF+/odLNGdlRpowVpkyZge3bN8Pd/TfY2VXDtGlzMHBgr2yvS0dHB6tW/YWtWzdi586tCA0NgZGRMaytbdCpUzdxvq5dnREdHYVDhw7g8OEDqFWrDiZOnIrffhudo32g/E8qlUAilartqTBSqYThjSibJIIg5Jvfmt69e8PIyAjr1v03NlZkZCTq1KmDefPmicHsSx8/fkTjxo2xZs0aNG/eXJw+fPhwxMbGYufOnTmqRy5XICwsJsP3kpISERr6EWZmv0BbW/mUbnYfTB8YGoPEXDjNltUH0xvo6aCYmR4SQwLy9MH0Eu0C0ClskSunFPOz3Dptml9paUnhHxiFhMT//6wJyYiOCsbOc4EIiUz++sI55FC9BCb0qYWALRPy/MklOsXKwGLwEoSHx/yQP9cCBbRgaFgwz9s2r9pVS0sKExN9jFt2EX7vI1S2nS/9DJ/Zn61t86JdTU31s3QJQ77qeXv16hW6dFEe5d/Q0BBFihTBq1evMl3ul19+wa+//or169ejTJkyKFasGLy9vXHlyhUsWbLku2rS0sq4ERWKzMNZVq/jSB2dIy4h+b8/hD8BiQTIP18Zclfqz/RH3UdJ1r6T/JDUcU1YXsjqF01VUXW7/qg/t6xg26pGftjvfBXeIiMjYWhomG66kZERIiK+nupXr14NNzc3tGnTBkDK8AdTp05Fy5Ytc1yPVCqBiYl+hu/Fx8sQEiKFTCbJNOBRxvLDB1/VfoZ9/Nmo45qwnwHbVXXYtqqRH9o1X4W3nBIEAZMmTcKbN2+wdOlSFClSBFevXsW8efNgZGQkBrrsUigEREbGZvheYmICFAoF5HIhx92nEsnP+UdeLlf8kL1SwH8/0x91H3/WzywAREbGKQ0B86PQ1pbBwCD7N9TkFlW3q0wmzRd/bNWBbasaqmxXQ8OCmnfa1NDQEFFRUemmR0REwMgo8wvhL168CE9PTxw9ehQ2NjYAgLp16yI0NBQLFizIcXgDkGkwk8u//y/zj/jHPSt+5P1O3bcfdR9/1P3KipTn4aruD2F2rpX9kai6XX9mbFvVyA/tmq/Cm5WVVbpr26KiohAcHAwrK6tMl3v58iVkMhmsra2VpleoUAEHDhxAXFwcChZUzbeDfHS/B5GapPwO8Fch56RSCYyN9X7aXk0iyp58Fd4aNWqE9evXK1375unpCalUigYNGmS6XIkSJSCXy+Hr6wtbW1tx+uPHj2FmZqaS4Jb6JILExATo6BTI9fUTaQwhGclyBaLifp6bbnKbVCqBTCbFkr/vICAw/dkHVaphWxT9WmftUXFElD/kq/DWo0cPeHh4wNXVFS4uLggMDMSiRYvQo0cPpTHe+vfvjw8fPsDLywtASugrXrw4xowZA1dXVxQtWhSXL1/G4cOHMXq0asankkplKFjQANHRKY8S0tEpAEkObsVTKCQQFEmAkHddsAq5BImJCUiSKyDk4fhKErkCSEzIlVPO+ZlCIfmh9/G/z6wcEJIRFxuB+37RSEz+cfc5rwQERuXpkAsAYFHU4NszEVG+kq/Cm5GREXbs2IHZs2fD1dUV+vr66Nq1K9zc3JTmS7lR4L9v+QYGBti+fTuWL1+OJUuWICoqChYWFnB3d0efPhk/LDw3GBqaAoAY4HJCKpUiKjIeSXl4IXRyggxILgB5dDgEuWrG5cqIRKYFmVyAQvFjX4MhlUp/6H1M+5lNlitw3y8alx7nbW8REdHPLF+FNwAoW7Ystm/f/tV5PDw80k0rVaoUVqxYoZqiMiGRSGBkZIZChUwgz0EIkskkMDLSw7xtN+EflHd//GpXMMeg9lb49L+FSAp5n2fb1S5cAsW6TkREROwP2zOV+jP9Ufcx7Wf2XWAUouLk7HEjIspj+S68aSKpVAqpVOfbM35BS0sKXV1dRMYpVDYyfUZiEwFdXV1oJURBEROaZ9vVKmQIXV1dxMXl/DFe+V3qz/RH3ce0n9nQqLz7zBIR0X94axMRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQahOGNiIiISIMwvBERERFpEIY3IiIiIg3C8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEG0VJ3AUSqIJVKIJVK8ny7Mhm/DxERkWoxvNEPRyqVwNhYT21BSqEQIJHkfXAkIqKfA8Mb/XCkUglkMimW/H0HAYFRebptC/NCmNC7plp6/YiI6Ofw3eEtKCgIYWFhsLS0hJ6eXm7URJQrAgKj4Pc+Qt1lEBER5aocn1c6e/YsWrVqBQcHB3Tq1AkPHjwAAISFhaFjx444e/ZsrhVJRERERClyFN7Onz+P0aNHw8TEBK6urhAEQXzP1NQU5ubmOHjwYK4VSUREREQpchTe1q5di1q1amHPnj3o3bt3uverVauGp0+ffndxRERERKQsR+HtxYsXcHJyyvT9woULIzQ0NMdFEREREVHGchTeChYsiLi4uEzf9/f3h7GxcY4K8vPzw8CBA1GtWjU0aNAAixYtQmJiYpaWDQwMxMSJE1GvXj3Y2dnByckJR48ezVEdRERERPlRju42rVu3Lo4cOYL+/funey84OBj79+9HkyZNsr3eiIgI9O/fH6VLl8bq1asRGBiIBQsWID4+HtOmTfvqskFBQXB2dkaZMmUwe/ZsGBgY4MWLF1kOfkRERESaIEfhbdy4cXB2dkbXrl3RqlUrSCQSXL58GdevX8e+ffsgCAJcXV2zvd69e/ciJiYGa9asEXvu5HI5Zs6cCRcXF5ibm2e67OLFi1GsWDFs3rwZMpkMAGBvb5+T3SP6blKpBFpaeTtIsEIhQKEQvj0jERFptByFNysrK+zevRtz587FypUrIQgCtmzZAgCoU6cOpk+fDgsLi2yv19vbG/b29kqnXJ2cnDB9+nRcuXIFnTt3znC56OhonDp1CvPmzRODG5E6GBcqAEGhgIGBbp5vWyGXI/xzHAMcEdEPLseD9JYvXx7bt29HREQE3r59C0EQULJkSZiamua4mFevXqFLly5K0wwNDVGkSBG8evUq0+UeP36MpKQkaGlpoU+fPrh37x6MjY3RsWNHjBs3Dtra2jmuSZW9Jz/rczBVvd/qbFeDgtqQSKUIOrICiaEBebZdHTMLFO04DtraMsjlCpVt52f9zAKq3Xe2q+auPz9j26pGftjv737CgpGREezs7HKjFkRGRsLQ0DDDbUREZD5SfkhICABg6tSp6N69O0aNGoWHDx9i1apVkEql+O2333JUj1QqgYmJfo6WpcwZGhZUdwkqlxgagMRPr/N8uz9D26oL21Y12K6qw7ZVjfzQrjkKb0eOHMnSfB07dszJ6rNNoUjpaahfvz7c3d0BAPXq1UNMTAy2bt0KV1dX6Opm/zSWQiEgMjI2V2tNSyaT5osPQV6LjIxTee/Qz9iuANtWlVTZtmxXfmZVgW2rGqpsV0PDglnq2ctReEsNSBmRSP57IHd2w5uhoSGiotI/SDwiIgJGRkZfXQ5ICWxp2dvbY/369Xj79i1sbGyyVUuq5GTVffB/VnK5gu2qImxb1WHbqgbbVXXYtqqRH9o1R+Ht3Llz6aYpFAoEBARgz549+PDhAxYuXJjt9VpZWaW7ti0qKgrBwcGwsrLKdLly5cp9db0JCQnZroWIiIgoP8rRVXclSpRI91/JkiVhb2+PVatWwdTUFLt27cr2ehs1aoSrV68iMjJSnObp6QmpVIoGDRp8tR5ra2tcvXpVafrVq1ehq6v7zXBHREREpClUcstE48aNcfLkyWwv16NHD+jr68PV1RWXL1/GwYMHsWjRIvTo0UNpjLf+/fujefPmSsu6ubnh/PnzmDt3Lq5cuYL169dj69atGDBgAPT09L57n4iIiIjyg+++2zQj/v7+OXqygZGREXbs2IHZs2fD1dUV+vr66Nq1K9zc3JTmUygUkMvlStMcHR2xbNkyrFu3Dnv27EHRokUxevRoDBs27Lv2hYiIiCg/yVF4u3XrVobTIyMjcfv2bXh4eKBp06Y5Kqhs2bLYvn37V+fx8PDIcHrr1q3RunXrHG2XiIiISBPkKLz17dtX6a7SVIIgQCaToVWrVpg6dep3F0dEREREynIU3nbu3JlumkQigaGhIUqUKAEDA4PvLoyIiIiI0stReKtTp05u10FEREREWaD+B3QRERERUZZlqefN0dExw2vcvkYikeDs2bM5KoqIiIiIMpal8FanTp1shzciIiIiyn1ZCm8LFixQdR1ERERElAW85o2IiIhIg3zXExaSkpLw6tUrREVFQRCEdO/Xrl37e1ZPRERERF/IUXhTKBRYunQpdu/ejfj4+Ezne/r0aY4LIyIiIqL0chTe1q9fjy1btsDZ2Rk1a9bEH3/8gQkTJsDQ0BC7d++GRCLB77//ntu1EhEREf30cnTN2+HDh+Hk5ISZM2eiYcOGAIBKlSqhe/fu2L9/PyQSCa5fv56rhRIRERFRDsPbp0+fUK9ePQCAjo4OACAxMVF83b59e/zzzz+5VCIRERERpcpReDM2NkZsbCwAQF9fHwYGBvD391eaJzIy8vurIyIiIiIlObrmrWLFivDx8RFf161bFzt27ECFChUgCAJ27twJGxubXCuSiIiIiFLkqOete/fuSExMFE+Vurm5ITIyEn369EGfPn0QExMDd3f3XC2UiIiIiHLY89a0aVM0bdpUfF2uXDmcPXsWN27cgEwmQ/Xq1WFsbJxbNRIRERHR/8tReBMEId2zTgsVKoRmzZrlSlFERERElLEcnTZt2LAh5syZg7t37+Z2PURERET0FTnqeatTpw4OHjyIv//+G+bm5nBycoKTkxPs7Oxyuz4iIiIiSiNH4W3ZsmWIj4/HhQsXcOrUKezZswfbt29HiRIl0Lp1azg5OaFChQq5XSsRERHRTy/HD6bX1dUVe9xiY2Nx/vx5nDx5Etu3b8emTZtQqlQpeHp65matRERERD+9HF3z9iU9PT20bdsWixcvxh9//AE9PT28ffs2N1ZNRERERGnkuOctVVxcHM6fP49Tp07h0qVLSExMhKWlJZycnHKjPiIiIiJKI0fhLSEhARcvXsTJkyfh7e2NuLg4lChRAn379kXr1q1RsWLF3K6TiIiIiJDD8FavXj3Ex8ejaNGi6N69O1q3bo2qVavmdm1ERERE9IUchbfOnTvDyckJtWrVyu16iIiIiOgrchTe/vzzz9yug4iIiIiyIFfuNiUiIiKivMHwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iDf9YSF+/fv48aNGwgNDUWvXr1QunRpxMXF4dWrVyhdujT09fVzq04iIiIiQg7DW2JiIsaPH49z585BEARIJBI0adIEpUuXhlQqxaBBgzBgwACMGDEit+slIiIi+qnl6LTpypUrcfHiRcyYMQOenp4QBEF8r0CBAmjVqhXOnTuXa0USERERUYochbcTJ06gR48ecHZ2hpGRUbr3y5YtC39//+8ujoiIiIiU5Si8hYaGwsbGJtP3ZTIZ4uPjc1wUEREREWUsR+Htl19+watXrzJ9/+7du7C0tMxxUURERESUsRyFt7Zt22Lv3r24d++eOE0ikQAA9u/fj1OnTqFjx465UiARERER/SdHd5sOHz4cDx48QJ8+fWBlZQWJRIL58+cjIiICnz59goODAwYMGJDLpRIRERFRjsKbjo4ONm/ejKNHj+L06dNQKBRITEyEjY0Nxo0bhw4dOog9cURERESUe7Id3uLj47F8+XLUrVsXHTp0QIcOHVRRFxERERFlINvXvOnq6mLfvn0IDQ1VRT1ERERE9BU5umGhUqVKeP78eW7XQkRERETfkKPwNnnyZJw8eRIHDhxAcnJybtdERERERJnI0Q0L7u7ukEgkmDZtGubMmQNzc3MUKFBAaR6JRIKjR4/mSpFERERElCJH4c3Y2BjGxsYoU6ZMbtdDRERERF+Ro/Dm4eGR23UQERERURbk6Jo3VfLz88PAgQNRrVo1NGjQAIsWLUJiYmK21rF9+3bY2NjAxcVFRVUSERERqUeOet4AQC6X4+jRo7h48SI+fPgAAChevDiaNGmCdu3aQSaTZXudERER6N+/P0qXLo3Vq1cjMDAQCxYsQHx8PKZNm5aldQQHB2Pt2rUwMzPL9vaJiIiI8rschbeoqCgMHjwYPj4+0NfXR8mSJQEAV69exZkzZ7Bnzx5s2bIFBgYG2Vrv3r17ERMTgzVr1sDY2BhASkicOXMmXFxcYG5u/s11LF68GI6OjmKgJCIiIvqR5Oi06fLly/H48WNMnToV165dw+HDh3H48GFcvXoVf/75Jx49eoTly5dne73e3t6wt7cXgxsAODk5QaFQ4MqVK99c/vbt2zh79ix+++23bG+biIiISBPkqOfNy8sLPXv2RO/evZWma2tro1evXnj16hU8PT3x559/Zmu9r169QpcuXZSmGRoaokiRInj16tVXl5XL5Zg9ezaGDx+OokWLZmu7X6OlpbrLAmWyfHfJYZ5Q9X7/rO0KsG1VSZX7znbV3PXnZ2xb1cgP+52j8Pb58+evDhNSpkwZREREZHu9kZGRMDQ0TDfdyMjom+vbvXs34uLiMGDAgGxvNzNSqQQmJvq5tj5KYWhYUN0l/LDYtqrDtlUNtqvqsG1VIz+0a47CW6lSpXD+/Pl0PW+pzp8/D0tLy+8qLDtCQ0OxatUqLFy4EDo6Orm2XoVCQGRkbK6t70symTRffAjyWmRkHORyhcrW/7O2K8C2VSVVti3blZ9ZVWDbqoYq29XQsGCWevZyFN569uyJ2bNnY+jQoeLdoQDw+vVreHh4iNe+ZZehoSGioqLSTY+IiICRkVGmy61cuRI2NjaoVasWIiMjAQDJyclITk5GZGQk9PT0oKWVsxtrk5NV98H/WcnlCrarirBtVYdtqxpsV9Vh26pGfmjXHCWa3r17IywsDBs3bsTly5eVV6ilBVdXV/Tq1Svb67Wyskp3bVtUVBSCg4NhZWWV6XKvX7/GrVu3ULt27XTv1a5dG5s2bUKjRo2yXQ8RERFRfpPjcd5Gjx6N3r1749q1a3j//j0AoESJErC3t4epqWmO1tmoUSOsX79e6do3T09PSKVSNGjQINPlJk+eLPa4pZo3bx50dXUxfvx42NjY5KgeIiIiovwmx+ENAExNTdGmTZvcqgU9evSAh4cHXF1d4eLigsDAQCxatAg9evRQGuOtf//++PDhA7y8vAAAFSpUSLcuQ0ND6OnpoW7durlWHxEREZG65eh+16tXr2LZsmWZvr98+XJcu3Yt2+s1MjLCjh07IJPJ4OrqiqVLl6Jr165wd3dXmk+hUEAul2d7/URERESaLkc9b+vWrcMvv/yS6fuBgYH466+/YG9vn+11ly1bFtu3b//qPB4eHt9cT1bmISIiItI0Oep5e/78OapWrZrp+1WqVIGvr2+OiyIiIiKijOUovCUmJiIpKemr78fHx+e4KCIiIiLKWI7CW/ny5cWbBb4kCALOnDmDsmXLfldhRERERJRejsJbnz59cPfuXYwZMwa+vr7igLjPnj3D2LFjcf/+ffTt2ze3ayUiIiL66eXohoUOHTrA398f69atg5eXF6TSlAyoUCggkUgwYsQIdOrUKVcLJSIiIqLvGOdt1KhRaN++Pby8vODv7w8AsLS0RLNmzfL0uaZEREREP5PvGqTX0tISgwcPzq1aiIiIiOgbviu8pfLz84Onp6f4DNLOnTvDwMAgN1ZNRERERGlkObzt2rULHh4e2LNnj9KzS8+fP4+xY8cqDR3i4eGBffv25fgZp0RERESUsSzfbXr+/HmULFlSKZAlJydj6tSpkMlkmD9/Po4dO4bffvsNHz58wPr161VSMBEREdHPLMvh7eXLl6hWrZrStBs3biAsLAz9+/dHp06dUL58eQwdOhStWrXCv//+m9u1EhEREf30shzePn/+jGLFiilNu3btGiQSCZo3b640vUaNGvj48WPuVEhEREREoiyHt8KFCyMkJERp2u3bt6GrqwtbW1ul6To6OtDW1s6dComIiIhIlOXwVrlyZRw+fBjR0dEAgBcvXsDHxwcNGzaElpbyfQ+vXr1K10tHRERERN8vy3eburq6omvXrmjZsiXKlSuHx48fQyKRYNiwYenm9fLyQr169XK1UCIiIiLKRs+bjY0NduzYgUqVKiEoKAhVq1bFxo0bUblyZaX5bty4gYIFC6JVq1a5XiwRERHRzy5bg/TWqFEDGzdu/Oo8devWxbFjx76rKCIiIiLKWJZ73oiIiIhI/RjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQahOGNiIiISIMwvBERERFpEIY3IiIiIg3C8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEG01F3Al/z8/DBnzhzcu3cP+vr66NChA8aNGwcdHZ1MlwkKCsL27dtx5coVvHv3DoUKFULt2rUxfvx4lChRIg+rJyIiIlKtfBXeIiIi0L9/f5QuXRqrV69GYGAgFixYgPj4eEybNi3T5R4/fgwvLy906dIFVatWRXh4OP766y9069YNx48fh6mpaR7uBREREZHq5KvwtnfvXsTExGDNmjUwNjYGAMjlcsycORMuLi4wNzfPcLmaNWvi1KlT0NL6b3dq1KiBxo0b48iRIxg0aFBelE9ERESkcvnqmjdvb2/Y29uLwQ0AnJycoFAocOXKlUyXMzQ0VApuAFCsWDGYmpoiKChIVeUSERER5bl81fP26tUrdOnSRWmaoaEhihQpglevXmVrXa9fv0ZoaCjKli37XTVpaaku38pk+So75xlV7/fP2q4A21aVVLnvbFfNXX9+xrZVjfyw3/kqvEVGRsLQ0DDddCMjI0RERGR5PYIgYM6cOShatCjatGmT43qkUglMTPRzvDxlzNCwoLpL+GGxbVWHbasabFfVYduqRn5o13wV3nLL6tWrcf36dWzevBl6eno5Xo9CISAyMjYXK1Mmk0nzxYcgr0VGxkEuV6hs/T9ruwJsW1VSZduyXfmZVQW2rWqosl0NDQtmqWcvX4U3Q0NDREVFpZseEREBIyOjLK1j//79WLt2LebOnQt7e/vvrik5WXUf/J+VXK5gu6oI21Z12LaqwXZVHbatauSHdlX/ids0rKys0l3bFhUVheDgYFhZWX1zeS8vL8yYMQNjxoxB165dVVUmERERkdrkq/DWqFEjXL16FZGRkeI0T09PSKVSNGjQ4KvL3rhxA+PHj0e3bt3g6uqq6lKJiIiI1CJfhbcePXpAX18frq6uuHz5Mg4ePIhFixahR48eSmO89e/fH82bNxdf+/n5wdXVFaVLl0aHDh1w//598b93796pY1eIiIiIVCJfXfNmZGSEHTt2YPbs2XB1dYW+vj66du0KNzc3pfkUCgXkcrn4+sGDB4iKikJUVBR69uypNG+nTp2wYMGCPKmfiIiISNXyVXgDgLJly2L79u1fncfDw0PpdefOndG5c2cVVkVERESUP+Sr06ZERERE9HUMb0REREQahOGNiIiISIMwvBERERFpEIY3IiIiIg3C8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQahOGNiIiISIMwvBERERFpEIY3IiIiIg3C8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQaJN+FNz8/PwwcOBDVqlVDgwYNsGjRIiQmJn5zOUEQsHHjRjRu3Bh2dnZwdnbG/fv3VV8wERERUR7KV+EtIiIC/fv3R1JSElavXg03Nzfs378fCxYs+OaymzZtwqpVqzBgwABs2LABRYoUwaBBg+Dv758HlRMRERHlDS11F5DW3r17ERMTgzVr1sDY2BgAIJfLMXPmTLi4uMDc3DzD5RISErBhwwYMGjQIAwYMAADUrFkTrVq1wpYtWzBjxoy82QEiIiIiFctXPW/e3t6wt7cXgxsAODk5QaFQ4MqVK5kud/fuXURHR8PJyUmcpqOjg+bNm8Pb21uVJRMRERHlKYkgCIK6i0hlb2+PLl26YMKECUrTGzZsiA4dOqSbnurvv//GrFmz8PDhQxQoUECcvn//fkybNg3379+Hrq5utusRBAEKheqaRyIBpFIpPkclIFmuUNl2vlRAR4ZCejqQx0RAkCfn2XYlMi3I9I2gUCigyk+dutoVYNuqirraFcibtuVnVoXb4WdWddv5ydo2L9pVKpVAIpF8c758ddo0MjIShoaG6aYbGRkhIiLiq8vp6OgoBTcAMDQ0hCAIiIiIyFF4k0gkkMm+3Yjfy7hQgW/PpAIyfSO1bFcqzZsOX3W1K8C2VRV1tSuQN23Lz6zq8DOrOj9b2+ZVu361BnUXQERERERZl6/Cm6GhIaKiotJNj4iIgJFR5gnb0NAQiYmJSEhIUJoeGRkJiUTy1WWJiIiINEm+Cm9WVlZ49eqV0rSoqCgEBwfDysrqq8sBwOvXr5Wmv3r1CsWLF8/RKVMiIiKi/ChfhbdGjRrh6tWriIyMFKd5enpCKpWiQYMGmS5Xo0YNGBgY4NSpU+K0pKQknDlzBo0aNVJpzURERER5KV/dsNCjRw94eHjA1dUVLi4uCAwMxKJFi9CjRw+lMd769++PDx8+wMvLCwBQoEABuLi4YPXq1TA1NYW1tTX27NmDz58/Y/DgweraHSIiIqJcl6/Cm5GREXbs2IHZs2fD1dUV+vr66Nq1K9zc3JTmUygUkMvlStOGDh0KQRCwdetWhIWFoUKFCtiyZQtKliyZl7tAREREpFL5apw3IiIiIvq6fHXNGxERERF9HcMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkT0g+HwnUQ/Noa3H4BCoVB6zQM30c8p9ckzEolEzZUQkSoxvGk4uVwOqTTlx/jmzRskJCTwwJ1L0obg+Ph4NVby4+MXju+jUChw4sQJXLhwQZw2ZswYXLp0SY1V/diSkpLUXQL9xBjeNJhcLodMJgMATJs2DYsWLcKRI0fS9cRR9gmCIIbgf//9F6tWrcK1a9fUXNWP48tnE6e2NUNczkgkEjx//hyjR4/GiRMnMHz4cFy5cgWmpqbqLk3jKRQKXLhwAV5eXuK0+fPn4/r162qs6sfA3/ecy1cPpqfsSQ1u48aNw8OHDzFmzBjY29uLPXGUc6lh4tChQ5gzZw46dOjAb9q5JO2Xjt27d8Pf3x86OjqoX78+6tatq+bqNJNEIoGbmxuCgoIwefJk6OrqYuPGjahUqZK6S9N4CQkJOH36NO7evYv4+HicOHECd+7cQdeuXdVdmkZL+wX58ePHCA0NRUREBBo1agR9fX1oaWkpzUPKGN403LFjx3Dnzh0sXrwYderUYXD7Dl8eKG7duoVFixZh9OjR6NKlCwwNDdVY3Y9BEAQxuI0ZMwY+Pj4wNTWFVCrFxo0bMWzYMHTt2hUlS5ZUc6WaSSaTISEhAQDw9u1bVKpUCbq6umquSjMpFAokJyejYMGCmDhxIlxcXDBr1izIZDJs3boV5cuXV3eJGi31WHvw4EEsWbIEWlpaiI6OhpmZGQYOHIhWrVrBzMxMzVXmX/xLryHi4uLw/PnzdNPfvn0LPT09VKlSRSm4fdkdze7pb/vyG96DBw9gYmKC5s2bM7jlktQ23rp1Kx4+fIjFixdjx44dOHDgAFxcXLBhwwb4+vry1H8O9evXD4cOHULz5s0xa9YsHD9+HLGxseouS+MkJCRg8ODBOHfuHGJjY2FiYgJTU1PExsZCX18fvr6+4rz8rObclStXMHfuXAwfPhybNm3C3bt3Ubt2bSxevBjHjh1Ld3kF/YfhTQMkJSXBxcUFhw8fTnegiIyMRExMDPT19QH8dyBJe71WbGwsu56/YuHChVi6dKn4OrUNnzx5Ai0tLVhYWChNTxUYGJh3Rf5gnj59imrVqqFq1aowMDDA69evsX//fjg5OaFhw4bsQc6CjP6wWVtbo2LFipg/fz6aNm2KOXPm4OTJk+INN/Hx8Xj27Flel6pxkpKSEBISggULFojXtjk7O+Ovv/6CiYkJtm7digMHDgAApFIpvxzn0IMHD1C5cmW0bt0atra2kEgk+Pz5M8zNzdGgQQPIZDKG40zwCKkBtLW10b9/f4waNQpSqRQfPnwQ36tYsSLi4+OxZ88eJCcnK/3Re/bsGY4dO4YnT56oo2yNEBUVBYVCAQcHB3FaahvWrFkT/v7+4o0KaQ/SAQEBWLNmjdI3cMoahUKBz58/Q6FQQFtbG69fv4azszPq1q2LuXPnokCBAli1ahUePHig7lLzrbTXDR4+fBhLly7F8uXLcfv2bQApx4wFCxagadOmmDt3Lo4cOYKnT59i3rx56Nu3L6KiotRZfr5nYGCAv//+G5aWlpg6dSouXLiAX3/9FY0aNcLatWuhp6eHbdu2iQFOIpEgISEBz549Q2Jiopqrz58y+rLx+PFjxMbGokiRIgCAIUOG4MmTJ1i5ciXKly+Pe/fuwcfHJ69L1QgMb/lcalho2rQp9PX1sXz5cowaNQqPHj0CADRv3hxlypTBpk2bcOLECXG5oKAg7Ny5E0+ePIGlpaVaatcEhQoVwm+//YZatWrh4sWLmDVrlvietbU1ihUrhl27dontLZFIkJSUhKtXr+L+/fu8ieEbMhqDUCqVokSJEnjy5Alu376NHj16wN7eHrNnz4aenh78/f1x584d3Lt3j9+6M6BQKJRuVvrrr79w+/ZtPH78GAMGDMDp06cB/BfgWrRogRkzZmD06NG4cOECtm7dikKFCqlzF/K11GOuoaEh1q5di7Jly2Lq1Km4dOkS4uLiYG5ujjVr1kBfXx/bt2/H7t27ERgYiDlz5mDmzJniNYeU4sWLF/j06ZP4mb1y5QoePnwIAKhcuTISEhLw9u1bDBs2DC9fvsT69etha2uL8PBw7NixAzdv3kRycrI6dyF/EihfS05OVnq9adMmoVWrVsKQIUOEBw8eCIIgCBEREULbtm0Fe3t7oUePHsL48eMFZ2dnoU6dOsLTp0/VUbZGUCgU4v/j4+OFKVOmCLVq1RLmz58vzrNr1y6hQYMGgrOzs3D48GHh4sWLwpo1a4Rq1aoJmzZtUlfpGiHtZzciIkKIiooSX3/69ElwdHQUbGxshNGjRwuJiYmCIAhCcHCw4O7uLrRu3VoICAjI85o1yezZs4VmzZoJt2/fFgRBEBYvXizY2NgINjY2wv/+9z+leY8ePSocOnRIePfunTpK1RhyuTzdtIiICKFPnz5CgwYNhHPnzgmxsbGCIAjCx48fhR49egh16tQRHB0dhQYNGggPHz7M65LztdDQUGHx4sVCt27dhM+fPwvHjh0T7OzshPPnzwuCIAh37twRKlWqJNStW1do0qSJ8Pz5c0EQBCExMVE4dOiQ0LRpU+Hs2bPq3IV8SyIIPFmvCQ4ePIguXboAAPbt24dt27ahRIkSGDNmDKpWrYro6GjxIvDY2FjY2Nigb9++sLKyUnPl+V9wcDCKFCmCjx8/YsuWLThz5gxatGiBqVOnAkg5LXXkyBHcuHED2trasLS0RLdu3TBgwAAA6e9SJeU2mT59Oh49eoTQ0FAMGjQIjo6OsLCwwNmzZ7F06VLIZDK4uLggKCgI9+/fx40bN7Bz507Y2tqqeS/yrxcvXmD+/Pno0qUL2rRpgy1btmDZsmWYNGkS7t+/j+PHj2Pp0qVo06aNukvVSH/++Sfq1asntl9kZCRcXV3x+vVrzJo1C/b29ihYsCBCQkJw5swZJCQkwNHREaVKlVJz5fnPoUOHsGPHDsTGxuLDhw+YMWMGOnToAG1tbUgkEhw7dgy///47GjZsCBcXF+jr6+Py5ctYt24dRowYgWHDhql7F/In9WZHyordu3cLderUEWJiYsRpe/fuFVq2bCkMGjRIuH//viAIyj1Jqf+mr/P29haaNGkihIaGCoKQ0iM0Y8YMoWHDhsLs2bPF+UJDQ4U3b94IL1++FD58+CBOz+ib+s8ubY/b5MmThcaNGwtz584V3NzcBFtbW2Hy5MnCmzdvBEEQhKdPnwr9+vUT2rZtKzg5OQnjx48Xv31T5kJCQoTDhw8LUVFRgpeXl1CjRg3h4MGDgiAIws2bNwUbGxuhYsWKwv79+9VcqeYJCwsTBg8eLFSpUkXw8vISp2fWA0ffNn36dMHGxkZo0qSJ4OvrKwhCynEi9e/UqVOnhCZNmggNGzYUateuLXTo0EHYtm2buDyPs+mx500DXLhwAaNHj8Y///yDsmXLitPT9sC5ubmhcuXKaqxSM/39999Yu3Ytzp8/L46HFRgYiPXr1+PcuXNKPXBfEtjj9lXR0dFYt24d6tevD3t7e8hkMuzZswcLFixAy5Yt4eLiIn6eg4KCoK+vD21tbejo6Ki58vxFoVBkePdtdHQ0DAwMMHnyZISHh2PJkiXiXee9e/dGSEgIPn/+DC8vLw518xUZ/R6/f/8ey5cvx+nTp7F8+XI0a9YMwH89cP7+/pg0aRKaNGnCz+tXJCcnQxAEzJs3D4mJifDx8YGOjg4WLlyIsmXLio93lEgk+PTpE6KiopCQkAAzMzP88ssvADL//P/s2CL5TEZ35FhYWEBXVxchISEA/numnrOzMwYOHIigoCDMmjWLQwB8Q0bfU+rWrYu4uDjxAlq5XA5zc3MMHz4cTZs2xfnz5zF79uwM18fglrmlS5eibt26OHPmDAoXLixerNyzZ09MnjwZp0+fxqZNm8SxC4sWLQp9fX3+IfxC2mcXP3/+HL6+vnjz5g2AlDsiBUFAWFgYoqKioK2tDQDw8/ODVCrFlClTcOrUKQa3r1AoFOLvcdobDVK/ELdo0QJubm44e/YsgP9uYjAyMsLy5ct5w1IG0h5ntbS0oK2tjYkTJ2Lu3Lno378/EhMTMXHiRLx8+VJpKBA9PT2UL18elStXFoOb8P83OFF6fMJCPpP6R27Pnj3Q1dVFrVq1UKRIERQrVgw3b95E3bp1xYM0kBLg4uLicPz4cR6kvyH1IP369WuYmprCwMBAvEU9NRhLJBIIgiAGOLlcjoMHD8LJyQm1atVSW+2axsrKCnZ2dnj27Jn4By4xMRE6OjpwdnYGACxatAgxMTFwc3PjtZkZSHtX6R9//IGHDx/iw4cPKFy4MBwdHfH777+jQIECsLOzw/bt27Fx40ZYWVnh6tWr+Pz5MypVqsRnm35DajBYsGABtLS0MHz4cBgYGABICXDjx4+HQqHAb7/9hhUrVqBJkyYwNDTErl27EBkZKfZ0Uoq0vZgfPnxAYmIipFKpGMa6dOkChUKBXbt2wd3dHUuXLkWpUqVw9uxZHD16FFOmTIG5ubm4Pn5BzhxPm+ZDFy9exMSJE5GcnAyJRAKpVIrIyEg0bNgQDRo0QK1atWBoaIjixYtDSyslf0dGRjK8ZcGlS5cwZswYaGlpoXz58qhatSr279+Pli1bYtiwYbC0tFT6phcYGIg3b97wmZtfkdFpDYVCAU9PT6xYsQLJycnYv38/ChcuLAY4ANi5cyc2btyIgwcPKh2wSdmUKVNw5coVTJw4EQUKFEBMTAwmTZoEBwcHLF68GHp6enB3d8f58+chCAKMjIywevVqVKhQQd2l51tfnirt168f3r59ix49eqBv375igAMAHx8fjBw5EomJiZg5cyZatWqljpI1yvHjx7Fu3TpERUUhPDwc3bt3R4cOHVC1alUAwP/+9z94eHggNDQUTZs2xcGDB+Hq6ooRI0aouXLNwfCWD2T0xy91ENPnz5/jzZs3OHLkCJ48eQIzMzOEhoZCEAQUL14c1apVw4IFC/gNJYvCw8Ph4+ODd+/e4c2bN7h37x7evn0LhUKBpKQklC5dGiVKlEC5cuVQoUIFpbv1eO1FemkHiw0ICIC2tjakUimKFCkChUKBM2fOYPny5ZBKpfDw8EgX4Pil4+v8/Pwwbtw4DB06FK1atYKOjg5evXqFDh06oE2bNpg2bRr09PQAAPfu3YNMJkOxYsVQtGhRNVeef6X9zKb9/I0bNw53795Fjx490K9fP6UAN2zYMDx48AAymQxnzpxReo+UnThxAlOnTsXgwYPh7OyMffv2YePGjWjUqBEGDRqEGjVqAAA8PT1x+vRpfPr0Ce3bt0fPnj0B8FrirOJpUzVLeyAJCwtDUlISTExMYGxsDACoV68e6tWrh4SEBDx//hxHjx7F+/fv8e7dOzx79gxOTk78oGcio4OAiYkJGjVqJL5OTEzEypUrcezYMUybNg1Pnz7F/fv3cf78+XQPRWZwU5b2tN6UKVPw8OFDBAUFoWjRoujRowd69+6Nli1bAgBWrFiBPn36YNeuXUoBjoPFKkt7PACA2NhYvHv3DkZGRtDR0cGbN2/Qo0cPNG/eHNOnT0fBggXh7e2NRo0aoXr16mqsXDOkbd81a9ZALpejZcuWsLW1xYoVKzB27Fjs3bsXgiBg4MCB0NPTQ0BAAHR1dbFixQrY2NgwuH2Fn58fPDw8xCE+fH19sWPHDlSpUgVXrlxBQkICRo4cierVq6NVq1Zo0aIFYmJixOMAvyBnHcObGqX94zdnzhzcvHkTgYGBKFasGIYPH466deuK16yUKlUKWlpaSEhIgK2tLWxtbdGiRQt1lp+vpQ1uly9fxtWrV/Hu3TvUrFkTDRs2RLly5QAAOjo6qF69Ovbu3Yv69euLd5Wl3slHmUs9yP7xxx+4ceMGRo8eDYVCgeDgYMyePRv+/v747bffxAC3du1atG/fHsePHxc/1/zi8R9BEJSenDBo0CDo6+tDKpWiQIEC4umn+vXrY9asWShYsCAuX76M9evXo3jx4uJnmjL2Zfv6+Pigb9++MDExEedZuXIlxo0bhwMHDuD58+eoX78+bt68iRcvXqBcuXK8hvAbkpKSUKJECXTq1An+/v4YNGgQmjVrhvnz5+Pvv//G7NmzUbBgQSQlJaFOnTqQSqVicOPNCdnDllKj1A/qb7/9hnPnzqF169YYMmQIihQpggkTJmD79u0ICgoCkPIYkfj4eNy/f1+NFWuO1FBw6NAhjB49Grdu3UJQUBCWLl0Kd3d3/PPPP+K8RkZGiI2Nxfv378VpqcGNVxV8nY+PD3x8fPDnn3+iQ4cO6N69u/ilIjY2Vrybr0WLFhg8eDCKFy+O6OhoNVed/8jlcvEzu27dOly7dg3h4eEoW7YsGjZsiNGjR8PR0VF8VqmBgQHCwsJw4sQJ6Ovro3Dhwmreg/wvtX3nzZsHHx8fLFu2DN26dYO5uTkEQRAfwbRixQq0bt0ar169wrJly/Dy5UssX75cvLmJMmdra4vRo0ejSJEi2LRpE0qXLo0xY8YAADp37gxLS0vcuHEDa9euRXBwsNKy/CKXPex5U4O0vUJ3797F7du3MXnyZLGHYujQoVi4cCG2bNmC4sWLo0ePHtDR0YGOjg4CAwPVWbpGef78OZYsWYIRI0bA2dkZRkZGePbsGSZOnCg+39HR0RGVKlVCkSJF4OPjg/LlyyutgweUr4uKisLHjx9RpEgRaGtr4+3bt+jduzfatGmDSZMmoUCBAnjy5AkqVqyI9u3bo1mzZuzRzEBqj9Djx4/h5+cHNzc32NvbAwD69u2LiIgI3LlzB506dYKWlhaePXuGbdu24d9//8WuXbvEyyzo62JiYvDkyRO0b99evHje398ff//9NyIiImBnZ4eePXvijz/+QP/+/REdHQ0TExP2uH0h7ennxMRECIKAAgUKAABKly6NxMREvHjxApaWluKdpiEhITA3N0erVq1QsmRJhuHvxPCWR9IGttT/KxQKxMXFISgoSLwzLCkpSRwXJygoCGvXrkWrVq1gbGyMFi1aoE6dOmrbB02R2tbBwcEQBAGNGzeGkZERFAqFeG1L//79ceDAATg6OorLcIyxr8voepSkpCRIJBKYm5sjODgY3bp1Uzqt5+npiX379mHevHn45ZdfGNy+YunSpdi8eTMsLCzQu3dv8fNYu3ZtDBo0CDKZDAMHDkTx4sVRoEABJCcnY/v27Txdmg3Jycl4/fo1bG1t4evrixs3bmD58uUwNzeHtrY2Dh8+DF1dXXTq1Anm5ua8C/oL/v7+KFmypPg37NSpUzh06BDCwsLQqlUrdO7cGWZmZtDR0YGFhQWuXLki9rTfvXsXMTExGDp0qNKpUn5BzhmeNs0DgiDg7Nmz2Lhxozht4sSJ2LZtGwoUKAB9fX3cunULgiBAW1sbiYmJAIDu3bsjIiICjx8/BpDyjMgve4boP6njiaX+PyEhAeHh4UoDaSYlJaFMmTKYMmUKLl68iAcPHkBPTw+7d+9G27Zt1VK3Jkg7WOylS5fEQY0dHBxQqlQpDBo0CG3atEHjxo0xZ84c6OvrIyQkBBcvXkShQoUY2rJgxIgRqFixIvz9/eHl5aU0aKyDgwM2bdqElStXYujQoZg4cSKf//oNGQ14bmRkhDFjxmDXrl3o168fNm/ejAEDBuDo0aNYv349KlSogKdPn6qh2vzv77//Rvfu3XHr1i1IpVKcPn0a7u7ukMlkMDMzw8qVKzFz5kxx4O1evXrB0NAQtWvXRp8+fTBlyhS0bNlS6SYlBrecY89bHkhKSsK7d++wfft2hISEICAgAA8ePMDgwYNRrFgxFC5cGAcOHEClSpVgbW0tfuOOj4+Hvr6+eCt7arc0/efRo0e4du0ahg4dCm1tbRw4cADXr1/HvHnzUKpUKRQrVgy7d+/G2LFjUbRoUfFgUaBAAfE/AChZsiQA3u2UkbQ31vz222/w8/ND06ZNYWlpCWNjYwwfPhxr166FXC7HuHHjoKenh9evX2Pjxo24dOkSdu7cybtKv/DlXaVAygjzf//9N3r06IHDhw+jatWqaNasGbS0tMSL7VNvqKGvS9u+V65cQVRUFGrUqAFjY2M4OzvD1tYWkZGRMDU1RaVKlQAABQsWhLa2Nq8fzISJiQlKliyJWbNmYfr06QgNDcXw4cMxZMgQaGtrw9vbG6NHj0ZCQgLc3d1RvXp1rFq1CseOHUNCQgKGDh0qDr3EHrdcoMoHp9J/IiIihAULFghVqlQRatWqJTx9+lR879GjR0LNmjWFvn37CufOnRMEQRDevn0ruLu7C61btxZCQkLUVXa+JpfLhX///Vewt7cXXFxchAMHDgg2NjaCh4eHOM+SJUuESpUqCatXrxb8/f0FQRCE+Ph4YdeuXYKjo6Pw8uVLdZWvcSZNmiQ0adJEuHjxohAeHi5Oj4uLEw4dOiS0aNFCqFu3rtC+fXuhU6dOQpMmTYQnT56or+B8Kj4+Xvz3rVu3hEuXLglRUVHitJiYGMHJyUlo3Lix4OnpKSQlJQmCwIdz58TYsWOFOnXqCDY2NkLDhg2Fv/76SwgNDRUEQRAfii4IghAQECBMmTJFaNiwofD27Vt1lZvvnT17VnB2dhacnJyEFi1aCIcPHxYE4b+2vHbtmmBnZycMHTpU8PPzE5dLTk4W/83Pce7gIL15aOHChfjf//4HbW1tODk54c8//xTfu3//vvitRSKRwMzMDOHh4di2bRtPjXxFdHQ0vLy8MGvWLCQlJWHSpEno3bu30kCw06dPx9GjR1GmTBnUrl0bkZGROHnyJEaNGoWhQ4eqeQ80g6+vL0aMGIHRo0ejQ4cOYu9kak+lXC5HdHQ0jhw5gpiYGFhaWqJmzZrixco/u7i4OGzatAmjRo1Susv84sWLiI2NReHCheHu7o4GDRrA2NgYsbGx6Nq1K+Li4jB58mQ0btxY6bF4lLHUa4YB4MCBA9iyZQsmTJiAMmXKYO3atbh//774NJXUIUI2btyIy5cv4+3bt+KpU1ImpOkp8/Lyws6dO3H//n3Mnj0bHTt2FE9Ry2QyXL9+XRzLbcKECWxPFWF4y0Pv379HUFAQTp48iTNnzqBp06aYNm2a+H5wcDC8vb3x8eNHcTDZ1NN5lF7qAeXy5csYOXIkgJQHzW/atAlAymlnXV1dACnXa1y/fh0+Pj6wsbFB48aNOaJ3Nnh7e2PYsGE4c+YMLC0txdDGtsuanTt3YvHixWjXrh3mzZuH48ePY/Xq1fj999+hq6uLQ4cO4dy5c/jjjz/g5OQEU1NTxMbGwtnZGQEBAVi6dKl4cw0pi4mJwcOHD8W7cwHgn3/+QWJionhqL9X06dNx6dIlMcDp6+tj3759ePnyJQYOHIjSpUurYQ80Q9rf9XPnzmHVqlUIDg7GypUrUbt2bQiCIF5ice3aNQwcOBDr1q3j51ZFGN7UICwsDOvWrYOXlxccHR0xffp08b3z58/j119/5Z2P2fD06VMEBgbi3bt3WLduHSpXrozNmzcDSLlpIe21gp8/f4aenp7YvrzGLb2M2uTRo0fo3r07lixZgtatW6eb78SJEzA1NRX/gDLUKQsLC8OOHTtw9OhR1KtXTwwJLi4u4jxTpkzBP//8g0mTJokBLiYmBgMHDsSiRYsYLDIgCALGjx8PiUSCRYsWQUtLCzdu3ED//v0BAG5ubnBxcVHqkUsNcE5OThg2bBiMjIzSHScoY2l/r8+fP48NGzYgOjoaM2bMSBfgPn36hGLFiqm54h9Y3p+pJUEQhODgYGH27NlCo0aNhKlTpwpv374V/vzzT6Fp06ZCYGCgusvTSDExMYKHh4dQt25dYfDgweJ0uVwu3L9/X7zWJVXaa14oRdprU27duiW+9vf3F5ycnAQXFxfB19dXnEehUAjv378XRo8eLezYsUNp+Z/dl5+v+Ph4Yfbs2UKHDh2EGjVqCAcPHhQEQRASEhLEeSZPnixUqlRJ+Pvvv8VrXfk5/bpPnz4JMTExgiAIwosXLwRBEIS9e/cKDRo0EPr27Su2b2JiorjMzJkzhWrVqgnLly/nNVjZlPbz6OXlJV4Dd+vWrXTvCwKvcVMVdjmoSeHChTFixAi0bt0anp6e6NmzJ/7991+sXLmSD5XOAUEQoKenh44dO2LUqFF49OgRhg4disDAQJw8eRJDhgzBrVu3lJZhz5CytHfoTZkyBfPmzcP27dsBABYWFnB1dcXFixexdu1aXL58GQDw7Nkz/PXXX7h79y4cHBzS3UH5sxIyGB5o8eLFKFiwIOzt7SEIAo4cOQIg5RFtqcMDzZ07F507d8asWbNw/vx5KBQKdZSvUczNzaGnp4dNmzahW7duuHr1KpydnTFq1Cjcv38fkyZNAgBoa2uLwwZNmzYNzs7O6NSpE3ves0kikYhPnmnWrBmGDBkCY2NjTJo0CdeuXUt3XGX7qgZPm6pZVFQUfH19ERAQgNq1a6NEiRLqLkljCf/fpR8TE4MjR45g9erV4vS+ffti1KhRaq5QM7i5ueHBgweYPHkyKlSooPSZPHLkCJYuXYrIyEjo6emhYMGCkMvlvND7C4mJifDw8MCWLVvQtm1b+Pv74/79+9i3bx9MTU2xadMm7N+/Hw4ODpg/fz4kEonSTTZz5sxBz549UbZsWTXvieZ49eoVpk+fjqCgIEyfPh3169fH3r17MXfuXLRo0QJLly4FAKV2JmXCF5c7ZDSkTUbzenl5iWMQdujQIU9q/dkxvNEPJfWAkpCQAF9fXzx69AglSpSAg4MDAF7j9i3/+9//sHbtWixbtgx2dnaQyWSIjY1FUFAQjIyMYGJiAl9fX7x8+RK+vr4oX748atSowS8dGYiMjMRff/2Fv//+GwUKFICHh4d453hkZCQ2btyIEydOoG7duliwYAEABovv9e7dO0yZMgWfPn3CzJkzlQKck5MTFi1apO4SNULqI+2+JW2AS336AuUN/hWjH0raQXjt7OzQq1cvBrdsiIyMhL6+PkqVKgWZTIbbt2+jT58+GDhwINq0aYNz587BxsYGbdq0wfjx49GuXTsGt0ykHVw7dQDptO8NGzYMbdq0wY0bNzBlyhQAYHD7TpaWlpg7dy6KFSuG6dOn4+rVq+jRowf+/PNPHD16VGl4JsrYs2fPMGzYMPz777/fnFcikYin9lODG/uD8gafsED51pdd+N+LwU1Z2vZN/bdUKsWnT5+wbt06hIeHw8vLCw0bNkT37t1x/vx5zJ07F/Xr10fBggXVXL1m6NOnD1q0aCEODyQIgjg8UGqAk0ql2LdvH2QyGWbNmqXmijVfaoCbMmUKpk+fjlmzZqF79+6QyWSoVq2ausvL9wwMDCAIgngd67d8OWQQryXOGwxvlC+lPRg8ePAAHz58QFhYGJo0aQIzM7Ms3daf2+HvR5KcnAwtrf9+/VPbacCAAXj58iVu3LiBX375BVOnTkX37t3FeQICAhAfH8/wlkUlSpRAiRIlUKpUKQiCAC8vLwBQCnClS5dG586d0atXL3WW+kNJDXDTpk3D2LFjsXr1anTp0kXdZeV7CoUCFhYWGDZsGNatW4dWrVp981rWtMfZAwcOwMrKCjVr1syLcn9qDG+UL6UeDP73v/9h8eLF0NfXR0xMDNauXYsBAwbAycnpq9dXpD2geHt7w9LS8qcfJyv14mNBEMTgtn79evj6+sLIyAjly5dH7969MWfOHMTExEAQBPGB8p8/f8bNmzdRrFgxjoeVA6ampuJgsV5eXkhKSsLQoUOxYcMGPH78GOvXr+eYWLnM0tIS06dPx8KFC9m235B2HDwAqF69OoyNjXH79m1UqFAh0xsX0h5nd+3ahTlz5mDx4sUMb3khTwYkIcqB69evCzVr1hS2b98uPoN08eLFQsWKFYW1a9cqjduUVtpxhrZv3y7Y2NgIV69ezZOa86uEhASha9euwr59+8Rpbm5uQp06dYQ+ffoInTp1EipVqiSMHDky3TiDt2/fFtzd3YU6deoojfFG2RcSEiIsWLBAqFWrllC/fn2hUaNGgo+Pj7rL+qFldpz4maU9Rp46dUqYP3++8PDhQ6V53N3dhcaNGyuNQ5jZOnbs2CHY2toKBw4cUE3BlA573ijfevLkCcqVK4dWrVrB3NwcAPD27VsUL14czZo1g7a2drpvhEKab4IeHh5YvHgxZs2apfTonJ9RXFwcihYtivnz56NAgQIoX7483rx5gxUrVsDe3h7R0dG4du0apk2bhmnTpmH9+vUAgP3792PdunUwNTXFzp07YW1treY90WxmZmYYOXIkmjZtyuGB8gifCfuf1CdJpB4jk5OT8fz5c/z777/YtWsXOnfujNq1a6Ndu3YYPHgwfHx8sHv3bvTv31/pEpQvj7Pz58/HrFmz0LVrV7Xs109J3emRSBCUv8UFBwcLgiAIU6ZMEVq2bClOHzx4sODg4CA8ffpUEISUJwBcv35dXDbtOnbu3CnY2toK+/fvz4vyNUJoaKjg7u4uVK1aVZg7d64wdOhQITY2Vmkeb29voUqVKsLq1avFaWfOnBE+ffqU1+USUS56+vSpsHDhQvEpFDt27BDatm0rCELKseHIkSOCs7Oz0KBBA6Ffv37Cnj17hNatWwu///57puvcvn27UKFCBR5n1YA9b5QvpH6L27dvH7y9veHu7g4bGxvcuHEDz549w9KlS/HixQusX78etra2iIyMxN69e1GyZElUr14dOjo64jp27tyJhQsXYtasWejWrZs6dytfEP7/W7KpqSl+++03SKVS7Ny5ExYWFggPD1e6+aBOnTpo1qwZbt68iejoaBgYGKB58+ZqrJ6Ivofw/0N36Onp4dKlS/j333/RunVr/PXXXxg1ahQEQYCpqSk6dOiABg0aICAgACtXrsTx48fh5+cHPz8/NG3aFC1btlRa78mTJ7F48WLMmDGDx1k14NgJpFZCmjGBAgMDsX79elSpUgUWFhZo2LAhwsLC0LNnT7x8+RIbN25EhQoVkJiYiHPnzuHu3buoWLGi0thY//zzD+bNm8cDyv+Ty+VKpzsKFy4Md3d39O7dGwEBAThz5oz4yCAgZUwyU1NTBAYG8k5doh9AcHAwJBIJLCwssGnTJoSHh+Ovv/7C4MGD4eLiku74UK1aNWzbtg1//PEHJkyYAFNTU1y8eBEKhULpcW3m5uZYsWKFeDc65S32vJFapR44Ll++jJcvX6JChQro1KkTJBIJSpcujVWrVmHUqFEwNzfHhw8fEBsbi+vXr2Pjxo0YMWKE2CuU2rsUHR2NlStXpvuW+DNKez3gyZMnERQUhMTERLRr1w5Dhw6FIAhYsmQJdHV10aJFC5iamiIoKEi8rpDhjUizrV27FkePHsXhw4ehp6eHqKgoxMTEQF9fH+fOnUP79u3TPYItdTBzOzs72NnZwdDQEDNmzMCIESNgaWkpzsc7StWLj8citQsMDMSIESPg7++PsmXLYu/evQD+G4vs9u3bmD59OuLi4hAREQErKyu0a9cO/fr1A8AnJ2RESHNB8dixY/HgwQMkJCRALpdDKpVixIgRsLe3x969e7F7927Url0blpaWCA8Px/3797F161bxUU5EpJkuX74MQ0ND2NnZiaHtyZMnSE5Ohru7O2QyGZYtW4by5cunWzb1UW2BgYHo2rUrfv/9d7Rv314Ne0EZYXijfOHEiRPYtWsX7t27h82bN+PXX3+FIAhQKBSQyWT4/PkzoqOjER8fD2NjYxQuXBgAg9u3LF++HAcPHsSyZctgYWEBmUyGRYsW4ezZs3B1dYWTkxO2bduG3bt3o1KlShg0aBCqVKmi9A2biDSL8MUA5VeuXIGbmxt2796NcuXKITk5Gc+ePcMff/wBqVSKFStWoFy5cgCAf//9F1WqVIGpqSkA4NGjR+jWrRuWLVsGJycntewPpce/epSnMvuu0KZNGwwaNAi2traYMWMGbt++DYlEAolEArlcDmNjY1hYWKBcuXJicBMEgcHtKxITE/Hs2TM4ODigTp06KF68OMzNzbF06VK0bt0a69evR0xMDMaPH482bdogMDAQTZs2ZXAj0nASiUTpWlYtLS2Ymppi6NCh8PPzg5aWFmxtbbFo0SIoFAqMHz8eZ86cwf/+9z+4uLjgxIkTAFKGFrl48SIaNWrE4JbPsOeN8kzab4P379+Hn58fJBIJihcvjnr16gEATp8+ja1btyI6OhozZ85ErVq1+JirHEpMTISzszNKliyJVatWAfhvJPWkpCS0adMGtWrVwrx58xAaGork5GRxPD0i0jwPHz6En58fOnXqBAA4ePAg3r17Bzc3N3h7e2PFihUIDg7G9u3bUbZsWSQnJ8PX1xeTJ0/G69evYWBggAEDBmDYsGHiOgMDA8XjAs905B+8YYHyTGoAO3ToEObOnYtixYohJCQEBQoUQMOGDTF37ly0bNkSUqkUmzdvxqxZs/Dnn3+idu3aaq5cM0mlUtja2uL27dt4+PAh7OzsxAFLpVIpTE1NERUVBSBl8Fgi0lzJyckICAjArFmzxJu/pkyZgj///BMA0KhRIwiCgJUrV2LAgAFigKtUqRL+97//4erVqzAxMYGdnZ24Pi0tLTG48UxH/sKfBOWp27dvY+HChRgxYgS2bt2Ks2fPYuzYsTh48CDWrFkDAGjevDmGDBkCLS0t/PbbbwgKCsr0dCtlTktLCwMGDEBQUBA2bNiA58+fi+9FRERAKpXil19+gSAIbF8iDaelpYWaNWvCxcUFO3bsgLu7O+bMmYPevXsjOTkZAODg4ICxY8eiSJEiGDBgAPz8/ACkPIXCwcFBDG4KhUJ8/nEqnv3IX9jzRnnq4cOHKFGiBNq2bSt+ozt16hQsLS3RuHFjcb7mzZsjISEBUqkURYsWVVO1ms/GxgYrV67EmDFj8PHjRzg6OsLc3ByXLl3Cy5cvMWfOHB6UiX4Q5ubmKFWqFJKTkyGVSvH06VMAKcEu9e5RBwcHACnDiPTu3RseHh7p7jZlD1v+x/BGKpPRtWrv3r0DABQrVgwAMHToULx48QIbNmyAra0trly5gqCgIHTq1Alt27b96rooaxo3boxdu3Zh4cKF2LNnD3R0dGBubo6dO3fCyspK3eURUS5IHdfR0NAQCxYsgJ+fH3bs2AGJRIKpU6dCR0dHKcBJpVJMnz4d9+/fz3CoEMrfGN5IZVLD1rVr11CzZk3o6OjAxsYGBw8exNu3b7F06VI8f/5cDG6fP3+Gt7c3pFKp+GimL9dFOWNnZ4eNGzciOjoaCoUChQoVUmpfItI8ab/UJiQkQE9PDw0aNAAAfPr0CVKpFNu2bQMAMcApFAq8fv0aDRs2xN69e3lmQ0MxvJFKffjwARMmTICzszPGjBmDhg0bokKFCujQoQP09PRw+PBhmJubIykpCefOncOZM2cwceJEBgsV0NfXh76+vrrLIKJckhrczp49i4MHD0IikaBWrVpwdnZGsWLF4OzsDADYtm0bpFIpfvvtN5w7dw6zZs3C8uXLYW9vD4BnNjQRwxuplImJCWxtbXHnzh0oFApYWFigR48e2LVrF8LDw/Hu3Ts8f/4cT58+xbp16zBy5Ei0atVK3WUTEWkELy8vuLm5oWHDhvD398ezZ89w/fp1LF26FMWLF4ezszMkEgk2btyICxcuIDw8HAMGDBCDG8AzG5qI47yRyqTeav7kyRP06NEDv//+O/r27Qsg5ZvikSNHcOXKFejq6qJUqVJo06aN+D7HEyIi+rqoqCgsW7YMZmZmGDZsGHR0dLBt2zbxdOi6detQqFAhhIaG4tGjR3jw4AFsbW3RokULADzOajKGN8p1qc/QA1IODrGxsZg1axY+fvyIxYsXizcrAMDLly+hp6cHLS0t8doLHlCIiL7Oy8sLHh4eAICBAweiSZMmAFIG5z5w4AB27twJc3NzrF27FoUKFUq3PI+zmo0/OcpVZ86cwe+//w5PT08AKbecGxgYoEmTJrh37x58fX0BpBw4AKBcuXIoXrw4ihQpAoADQRIRZYWxsTEeP36MmzdvIjg4WJyuo6OD7t27o1+/fggJCYGLi4s4GHdaPM5qNv70KFd9+vQJYWFhmDBhAkaOHIlDhw4BAJycnNCiRQssXboUnz9/TnfgSL3mgtdeEBFlLO2Jstq1a2Pbtm0oXLgw9u/fL34xBlIG3e3evTt69uyJ169f49q1a+ool1SIp00pxzK7Q+nz58948OABVq1ahZCQEJiammL06NF4+/YtTp8+jUGDBonXXBARUebSHmfj4uIglUpRoEAB8f07d+5gxIgRqFixIiZPngxra2vxvaSkJLx69Qo2NjZ5XjepFsMb5UjaA4qPjw9CQkIQGhoKR0dHGBgYQEdHB+Hh4Xj48CG2bt0Kf39/FC5cGA8fPkSzZs3ER2EREVHG0h5nT548iX379iEkJASFChXCwIEDUatWLZiZmeH27dtwdXUVn2ea0aC7vMbtx8LwRt/l4MGDWLx4MXR0dBATEyMeVFq2bKl0Y8Lhw4fh4+OD3bt3Y/To0XB1dVVj1UREmuPYsWOYNGkSunTpgqJFi8LX1xcPHjxA/fr1MW7cOJibm+Pu3bsYNWoUrKysMHXqVNja2qq7bFIhhjfKsWvXrsHV1RVjx45FvXr1YGNjg2nTpuHIkSMYM2YMBgwYAIlEAplMJi7z/v17lChRAgAHhiQiykjaXrKwsDAMHToUdevWxahRo6CnpwcAqFevHqytrbFo0SLxi/Lt27fRp08frF69Gs2bN1db/aR67EOlHHv48CEqVaoEJycn8ZqKkJAQFCtWDA4ODtDS0koXzooXLw4g5eDE4EZE9J+LFy8iLCwMUqlUvCM/JiYGAQEBqFGjhhjcRowYAR0dHUyaNAnFihVDYGAg4uPjUatWLXh7ezO4/QQY3ihLMuqgffz4MaKjo8Xx2YYMGYLHjx9j1apVKF++PO7evYsHDx4oLZMa2HjtBRHRf7y8vDBu3Dhs2LAB4eHh4jFSR0cHMplMHO5j2LBhePr0KTZu3IgKFSrAx8cHa9asEYcLSTteJv24+BeUvint6c2XL1/ixYsXAIDKlSsjMTERr169wtChQ/HixQusX79efMi8h4cHbt68ieTkZHWWT0SU7zVv3hzt27fHuXPnsGHDBoSFhQEAdHV1Ubx4cRw/fhz9+vWDr68vNm7cCFtbWyQnJ+Pu3bt4/vw5EhISlNbHL8g/Nv506avSBrejR49i/Pjx8PDwQEREBOrVqwd/f3/06NEDfn5+2Lx5MypUqICkpCRcuHABDx8+RNmyZaGlxUfoEhFlJjExEQAwa9YsNGrUCBcuXBADnJGREf744w/cvn0bN2/exKRJk2BtbY2oqCgcO3YMq1evRvv27VGuXDk17wXlJd6wQFly9OhR/Pnnn3BxcYGjo6N4J5OnpyfGjx+PWrVqYcSIETA0NMSVK1fw119/YcSIERg2bJiaKyciyr/SfkF+9uwZ3rx5gzlz5kAQBLRv3x5Dhw6FqakpLl68iLFjx6J8+fIwMjKClpYWHjx4gAEDBmD48OHp1kU/NoY3+iZ/f38MGTIE7du3x7Bhw6CtrS1O19HRwcePH/H7778jISEBcXFxKFmyJNq3b48BAwYA4PhCRERppYastGHryJEjmDFjBtq1a4fY2Fi8efMGL1++RK9evcQA9+TJE5w/fx5Pnz5F5cqVUb58eTRr1gwAj7M/G57Pom+Kj49HbGws7OzsoK2tjbCwMMyePRs+Pj4ICAjA+PHjsX//foSHhyMhIQEmJibires8oBARKfP19YWtra0Y3D5+/Ihly5ahd+/eGDNmjPgEBXd3dxw7dgwAMHToUFSsWBEVKlRI17vG4+zPh+GNvsnQ0BDR0dHYt28fPD09cfPmTUgkEvTq1QuxsbFYtmwZypYti6ZNmyotx4fMExEp27x5M44ePYodO3bA2NgYEokEMTExiIyMRPXq1VGgQAEkJSVBW1sbCxYswMiRI7Fjxw5IpVIMHjwYpqam6dbJ4+zPhz9x+iZzc3OsW7cOz549w6dPn+Dg4CA+o9TJyQnFixfP8ODBay+IiJS1bNkS8+fPh4mJCUJCQgCkHGOlUikeP34MIOXB8qk3MUybNg3GxsY4ffo0VqxYke6uUvo5seeNssTe3h7//PMPdHR0xGve4uPj4ePjAwAwMTFRZ3lERBqhZMmSAICbN29iwoQJmDp1Klq0aIGWLVvCy8sLVapUgaOjI3R0dABAfJaphYWF2DNHxPBGWaavry/+++HDh3j06BEWL16MkSNHolq1auorjIhIwxQtWhTFihXD8uXLYWpqitGjR2Pw4MHYvHkzoqKi0KFDB0RFReHFixcoW7YsFi5ciEKFCqm7bMoneLcpZZu/vz8mTpyI0NBQ9OzZU7yrlLepExFlnb+/PyZPnoyPHz9i+fLlKFiwIKZNmwZfX1+UKFECenp6ePToEUaPHg0XFxcAPM5SCoY3yja5XI7Hjx8jKSkJNWvWBMC7nYiIcuLdu3eYPHkyPn36hKVLl6JMmTI4f/48PD09UaRIEVSvXh2dO3cGwOBG/2F4o+/GAwoRUc6lDXCzZs1C/fr10x1X+QWZ0uIngb4bgxsRUc5ZWlpi3rx5sLCwwOTJk3HmzJl0x1UGN0qLnwYiIiI1s7S0xMyZM2FqaoqYmBh1l0P5HE+bEhER5RNRUVG8q5S+ieGNiIgon+G1xPQ1PG1KRESUzzC40dcwvBERERFpEIY3IiIiIg3C8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EpDEcHR3h7u6utu27u7vD0dFRaVpMTAymTJmCBg0awMbGBnPnzkVAQABsbGxw6NChPK+xb9++6Nu3b55vl4jyjpa6CyAiAlIezr1582ZcuXIFQUFB0NbWhrW1NZycnODs7AxdXV11l5ihDRs24PDhwxg5ciRKliyJsmXLqnybL1++xKlTp9CpUydYWFiofHtElL8wvBGR2l28eBFjx46Fjo4OOnToAGtrayQlJeHOnTtYvHgxXr58idmzZ6u7TMyePRtfPpTm+vXrqFq1KkaNGiVOEwQBDx8+hJaWag6xL1++xJo1a1CnTp104W3Lli0q2SYR5R8Mb0SkVv7+/nBzc0Px4sWxY8cOFC1aVHyvd+/eePv2LS5evKi+AtPQ1tZONy00NBTlypVTmiaRSFCgQIG8KkuJjo6OWrZLRHmH17wRkVpt3rwZsbGxmDt3rlJwS1WqVCn0798/w2U/f/6MhQsXol27dqhevTpq1KiBIUOG4NmzZ+nm9fDwQJs2bVC1alXUrl0bnTt3xrFjx8T3o6OjMXfuXDg6OqJy5cqwt7fHwIED8fjxY3GetNe83bhxAzY2NggICMDFixdhY2Mjvs7smjc/Pz+MHTsW9erVg52dHVq2bInly5eL779//x4zZsxAy5YtYWdnh7p162LMmDEICAgQ5zl06BDGjh0LAOjXr5+43Rs3bgDI+Jq30NBQTJ48GfXr10eVKlXQvn17HD58WGme1Jq3bNmCffv2oVmzZqhcuTK6dOmChw8fZtj+RKQe7HkjIrW6cOECSpYsiRo1amR7WX9/f5w9exatWrWChYUFQkJCsG/fPvTp0wcnTpyAubk5AGD//v2YM2cOWrZsiX79+iEhIQG+vr548OAB2rVrBwCYPn06Tp8+jT59+qBs2bL4/Pkz7ty5Az8/P1SqVCndtsuWLYtFixZh/vz5KFasGAYOHAgAMDU1RVhYWLr5nz17ht69e0NLSwvOzs4oUaIE3r17h/Pnz8PNzQ0A4OPjg3v37qFNmzYoVqwY3r9/jz179qBfv344ceIEChYsiNq1a6Nv377w8PDA8OHDYWVlJdaTkfj4ePTt2xfv3r1D7969YWFhAU9PT7i7uyMyMjJdMD5+/DhiYmLg7OwMiUSCzZs3Y/To0Th79myGPY9EpAYCEZGaREVFCdbW1sKIESOyNH+TJk2EiRMniq8TEhIEuVyuNI+/v79QuXJlYc2aNeK0ESNGCG3atPnqumvWrCnMnDnzq/NMnDhRaNKkSbqahg0blq4Ga2tr4eDBg+K03r17C9WrVxfev3+vNK9CoRD/HRcXl26b9+7dE6ytrYXDhw+L006dOiVYW1sL169fTzd/nz59hD59+oivt2/fLlhbWwv//POPOC0xMVFwdnYWqlWrJkRFRSnVXKdOHeHz58/ivGfPnhWsra2F8+fPZ9gmRJT3eNqUiNQmOjoaAKCvr5+j5XV0dCCVphzG5HI5wsPDoaenhzJlyuDJkyfifIaGhvj06dNXT/8ZGhriwYMHCAwMzFEtXxMWFoZbt26hS5cuKF68uNJ7EolE/HfaO2qTkpIQHh4OS0tLGBoaKu1Pdnh7e6NIkSJo27atOE1bWxt9+/ZFbGwsbt26pTR/69atYWRkJL6uVasWgJReTiLKH3jalIjUxsDAAEDKWGk5oVAosHPnTuzevRsBAQGQy+Xie8bGxuK/hw4diqtXr6Jbt24oVaoUGjRogLZt26JmzZriPBMmTIC7uzsaN26MSpUqwcHBAR07dkTJkiVztnNppAYfa2vrr84XHx+PDRs24NChQwgMDFS6szUqKipH237//j1KlSolhtxUqadZP3z4oDT9l19+UXqdGuQiIyNztH0iyn0Mb0SkNgYGBihatChevHiRo+XXr1+PlStXokuXLhg7diyMjIwglUoxb948peBTtmxZeHp64uLFi7h06RLOnDmD3bt3w9XVFWPGjAGQ0uNUq1YteHl54cqVK9iyZQs2bdqE1atXw8HBIVf291tmz56NQ4cOoX///qhWrRoKFSoEiUQCNze3dEOUqIpMJstwel5tn4i+jeGNiNSqSZMm2LdvH+7du4fq1atna9nTp0+jbt26mDdvntL0yMhImJiYKE3T09ND69at0bp1ayQmJmL06NFYv349XFxcxGE9ihYtit69e6N3794IDQ1Fp06dsH79+u8Ob6m9d8+fP//m/nTs2FHpKRIJCQnpet3Snmr9lhIlSsDX1xcKhUKp9+3Vq1cAkO40LhHlf7zmjYjUasiQIdDT08PUqVMREhKS7v13795hx44dGS4rk8nS9QidOnUq3XVr4eHhSq91dHRQtmxZCIKApKQkyOXydAHJzMwMRYsWRWJiYk52S4mpqSlq166NgwcPpjtNmbb+jHq9PDw8lE4HA0DBggUBZO1UaqNGjRAcHIyTJ0+K05KTk+Hh4QE9PT3Url07W/tCROrHnjciUitLS0ssWbIEbm5uaN26tfiEhcTERNy7dw+enp7o3Llzhss2btwYa9euxaRJk1C9enU8f/4cx44dS3ed2uDBg1G4cGHUqFEDZmZmePXqFXbt2gUHBwcYGBggMjISDg4OaNmyJWxtbaGnp4erV6/Cx8cn156lOnXqVPTs2ROdOnWCs7MzLCws8P79e1y8eBH//POPuD///PMPDAwMUK5cOdy/fx9Xr15Vun4PACpUqACZTIZNmzYhKioKOjo6qFevHszMzNJt19nZGfv27YO7uzseP36MEiVK4PTp07h79y4mT54sXndIRJqD4Y2I1K5p06Y4evQotmzZgnPnzmHPnj3Q0dGBjY0N3N3d0b179wyXGz58OOLi4nDs2DGcPHkSFStWxIYNG7B06VKl+ZydnXHs2DFs27YNsbGxKFasGPr27YuRI0cCSLnLs2fPnrhy5QrOnDkDQRBgaWmJ6dOno1evXrmyj7a2tti/fz9WrlyJPXv2ICEhAcWLF4eTk5M4z5QpUyCVSnHs2DEkJCSgRo0a2LZtG4YMGaK0riJFimDmzJnYsGEDpkyZArlcjp07d2YY3nR1deHh4YElS5bg8OHDiI6ORpkyZTB//vxMQzER5W8SgVehEhEREWkMXvNGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iD/B+ObYMdGn56KAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_differences(\"Precision score differences\", precision_scores, precision_scores_tuned)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### F1 Score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAm8AAAHPCAYAAAAFwj37AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACAu0lEQVR4nO3ddVhUWQMG8HdmKAEpFVxFbMDCREXXwsRuVLBFdLFQVzHW7o7VtQvbtVusVbHbtcUCg5bOmfv94cddRhBhBIbR9/c8Pjp3bpx7GC/vnHvOuRJBEAQQERERkUaQqrsARERERJR5DG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRETZbN++fbCxsUFAQIC4rGfPnujZs6fSeiEhIRg2bBhq1aoFGxsbbNq0CQDw+vVr9OvXD9WrV4eNjQ1Onz6dm8UnojxOS90FIKK8Yd++fRg3bly677m5uWH06NEAgEuXLuHYsWO4f/8+/Pz88Msvv+Ds2bOZPk5MTAzWr1+PU6dOISAgALq6uihcuDDs7e3h5uYGCwuLbDkfTTB79mxcvHgRQ4YMQcGCBVGxYkUAgJeXFwICAuDp6Yn8+fOLy4mIAIY3IvrCsGHDYGlpqbTM2tpa/PeRI0dw7NgxlC9fHubm5lnad1JSElxdXfHy5Uu0b98erq6uiI2NxfPnz3HkyBE0bdr0hw1v69evT7Ps6tWraNy4Mfr37y8ui4+Px507dzBo0CC4urrmZhGJSEMwvBGRkvr166NSpUpffd/T0xPTp0+HtrY23N3d8fz580zv+/Tp03j06BEWLFiANm3aKL2XkJCApKQklcudVbGxsdDX18+14+no6KRZFhoaCiMjI6VlYWFhAJBm+fdISEiAtrY2pFL2lCH6EfB/MhFliYWFBbS1tVXa1t/fHwBQrVq1NO/p6urC0NBQaZmfnx+GDx+O2rVrw87ODs2bN8fixYuV1nn06BEGDBiAatWqoWrVqujduzfu3r2rtE5KH7Tr169jypQpcHBwQIMGDcT3//nnH/To0QNVqlRB1apVMXDgwEyH0ufPn6NXr16ws7ND/fr1sXLlSigUijTrpe7zllIeQRCwbds22NjYwMbGBsuXL0ejRo0AAPPmzYONjQ0cHR3FfQQGBmLcuHGoU6cOKlasiFatWuHvv/9WOs61a9dgY2ODo0ePYvHixahXrx4qV66M6OhoAMC9e/fQv39/VK9eHZUrV4arqytu3bqltI/ly5fDxsYGb968gZeXF2rUqIHq1atj3LhxiIuLS3NuBw8eROfOnVG5cmXY29vDxcUFly5dUlonM3UcHByMcePGoX79+qhYsSJ+/fVXDB48WKnvIBGx5Y2IvhAdHS22/qQwMzPLln0XKVIEAHDgwAH89ttvkEgkX133yZMncHFxgZaWFpydnVG0aFG8ffsWZ8+ehaenJ4DPwcnFxQUGBgYYMGAAtLS0sGvXLvTs2RNbt25F5cqVlfY5depUmJmZwcPDA7GxsWJZvLy88Ouvv2L06NGIi4vDjh070KNHD+zfvz/NLeTUgoOD0atXL8jlcgwcOBD58uXD7t27oaurm2E92NvbY968eRgzZgzq1q2Ldu3aAQBsbGyQP39+zJ49G61bt0b9+vVhYGAA4PPghq5du0IikcDFxQVmZma4cOECJkyYgOjoaPTp00fpGCtXroS2tjb69++PxMREaGtr48qVK3Bzc0PFihUxZMgQSCQS7Nu3D71798b27dthZ2entI8RI0bA0tISI0eOxKNHj7Bnzx6YmZnh999/F9f5888/sXz5clStWhXDhg2DtrY27t27h6tXr+LXX3/NUh0PHToUL168gKurK4oWLYqwsDD4+vriw4cPGf4ciH46AhGRIAh79+4VrK2t0/3zNQMHDhQaNWqU6WPExcUJzZs3F6ytrYVGjRoJXl5ewp49e4SQkJA067q4uAhVq1YV3r17p7RcoVCI//7tt9+EChUqCG/fvhWXBQYGClWrVhVcXFzSnFv37t2F5ORkcXl0dLRQo0YNYeLEiUrHCA4OFqpXr55m+ZdmzpwpWFtbC/fu3ROXhYaGCtWrVxesra0Ff39/cbmrq6vg6uqqtL21tbUwdepUpWX+/v6CtbW1sG7dOqXl48ePF+rWrSuEhYUpLff09BSqV68uxMXFCYIgCFevXhWsra2Fxo0bi8sE4XO9NWvWTOjXr59SHcbFxQmOjo5C3759xWXLli0TrK2thXHjxikdy8PDQ6hZs6b4+vXr14Ktra3g4eEhyOVypXVTjpHZOo6IiEj3vIkoLd42JSIlkyZNwsaNG5X+ZBc9PT3s2bNH7KC/b98+TJgwAb/++iumT5+OxMREAJ/7fd24cQOdOnUSW+tSpLTWyeVy+Pr6okmTJihWrJj4vrm5OVq3bo1bt26JtwpTdO3aFTKZTHx9+fJlREZGolWrVggLCxP/SKVSVK5cGdeuXcvwfP755x9UqVJFqcXKzMwsTX++7yUIAk6dOgVHR0cIgqBU1l9//RVRUVF4+PCh0jbt27eHnp6e+Prx48d4/fo12rRpg/DwcHH72NhYODg44MaNG2lu93br1k3pdY0aNfDp0yexXk+fPg2FQgEPD480/elSfk6ZrWM9PT1oa2vj+vXriIiIyJ6KI/pB8bYpESmxs7PLcMDC98qfPz/GjBmDMWPG4N27d7hy5Qo2bNiArVu3wtDQEJ6enmLfuNSjXL8UFhaGuLg4lCxZMs17pUuXhkKhwIcPH1C2bFlx+Ze33l6/fg0A6N27d7rH+LIP3pfev3+f5tYsgHTL9D3CwsIQGRmJXbt2YdeuXV9dJ7WvnevYsWO/epyoqCgYGxuLr78MzimDKCIiImBoaIi3b99CKpWidOnSX91nZutYR0cHo0ePxty5c1G3bl1UrlwZDRs2RPv27VGoUKGv7p/oZ8TwRkRqU7RoUXTu3BlNmzZFkyZNcPjwYbE/W074si+aIAgAPg8OSC8gpG6lU6eUFrG2bduiQ4cO6a5jY2Oj9Dp1qxvw37mOGTMG5cqVS3cfX46+/dro1JR9ZUZW6rhPnz5wdHTE6dOncenSJSxduhRr1qzB5s2bUb58+Uwfk+hHx/BGRGpnbGyMYsWKiaMPU26DPnv27KvbmJmZIV++fHj16lWa916+fAmpVIpffvklw+OmHKdAgQKoU6dOlstdpEgRvHnzJs3y9Mr0PczMzGBgYACFQqFSOYH/ztXQ0FDlfXzJysoKCoUCfn5+Xw2EWa1jKysr9OvXD/369cPr16/Rvn17bNiwAQsWLMiWMhP9CNjnjYhyzZMnT9Lc3gOAd+/ewc/PT7zdaGZmBnt7e+zduxfv379XWjelJUcmk6Fu3bo4c+aM0lQSISEhOHLkCKpXr/7N25716tWDoaEhVq9ene4cc+mVNbUGDRrg7t27uH//vtI2hw8fznC7rJLJZGjevDlOnjyZbqD9VjkBoGLFirCyssKGDRsQExOj0j6+1KRJE0ilUqxYsSJNf7mUn1Nm6zguLg4JCQlK71lZWcHAwEDsC0lEn7HljYiy5MmTJ+LjsN68eYOoqCisXLkSAGBra6s0L9mXfH19sXz5cjg6OqJy5crQ19dHQEAA9u7di8TERAwdOlRcd+LEiejevTs6dOgAZ2dnWFpa4t27dzh//jwOHjwI4PNUFpcvX0aPHj3Qo0cPyGQy7Nq1C4mJiUrTWXyNoaEhpkyZgjFjxqBjx45o2bIlzMzM8P79e/zzzz+oVq0aJk2a9NXtBwwYgIMHD2LAgAHo1auXOFVIkSJF8PTp00zVZ2aNGjUK165dQ9euXdGlSxeUKVMGERERePjwIa5cuYLr169nuL1UKsWMGTPg5uaG1q1bo2PHjrCwsEBgYCCuXbsGQ0NDrFq1KktlKl68OAYNGoSVK1eiR48eaNasGXR0dPDgwQOYm5tj1KhRma7j169fo0+fPmjRogXKlCkDmUyG06dPIyQkBK1atfqeqiP64TC8EVGWPHr0CEuXLlValvK6Q4cOGYa3Zs2aISYmBr6+vrh69SoiIiJgZGQEOzs79O3bF7Vr1xbXtbW1xe7du7F06VLs2LEDCQkJKFKkCJycnMR1ypYti23btmHhwoVYvXo1BEGAnZ0d5s+fn+5AgvS0adMG5ubmWLNmDdavX4/ExERYWFigRo0a6NixY4bbmpubY8uWLZgxYwbWrFkDExMTdOvWDebm5pgwYUKmjp9ZBQsWxJ49e7BixQr4+Phgx44dMDExQZkyZcTnzn5LrVq1sGvXLqxcuRJbt25FbGwsChUqBDs7Ozg7O6tUruHDh8PS0hJbt27F4sWLkS9fPtjY2Ihz1wGZq+PChQujVatWuHLlCg4dOgSZTIZSpUphyZIlaN68uUplI/pRSYSs9DwlIiIiIrVinzciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQahPO8ZUAQBCgUP+ZMKlKp5Ic9N3Vj3eYM1mvOYd3mDNZrzvlR61YqlUAikXxzPYa3DCgUAsLC0j5GRtNpaUlhamqAyMhYJCcrvr0BZRrrNmewXnMO6zZnsF5zzo9ct2ZmBpDJvh3eeNuUiIiISIMwvBERERFpEIY3IiIiIg3C8EZERESkQRjeiIiIiDQIR5tmA4VCAbk8Wd3FyDSFQoL4eBkSExMgl/94Q63V6WerW5lMC1IpvwMSEeUmhrfvIAgCIiPDEBcXre6iZFlIiBQKxY81xDqv+NnqNl8+QxgZmWVqbiIiIvp+DG/fISW4GRqaQkdHV6N+eclkkp+iZUgdfpa6FQQBiYkJiI4OBwAYGxdQc4mIiH4ODG8qUijkYnAzNDRSd3GyTEtL+sNNbphX/Ex1q6OjCwCIjg5H/vymvIVKRJQLeKVVkVwuB/DfLy+in1XK/wFN6vdJRKTJGN6+kybdKiXKCfw/QESUuxjeiIiIiDQI+7zlAKlUAqk091sjFAoBCsWP31Gefl4ymXq+b/L/FhHlJQxv2UwqlcDERF8tv2TkcgU+fYpV+ZfMlSu+2Lt3F548eYSoqCgYGRnD1rYcmjVzQuPGzXKlM/qxY4cxa9ZUHDlyGiYmJpnebv361di5cyt8fC7mXOFIbSQSCQSFAkZG+dRyfIVcjvBPcQxwRJQnMLxlM6lUAplMigXbbiEgMCrXjmtpkR+jXapDKpWo9Atm9eoV8PbeiPr1G8HTcwwKFCiIsLAwXLx4HtOnT4KRkTFq1XLI9nJ/ycHhV6xatRGGhoZZ2q5Nm/aoU+fXHCoVZYZMJoGWVs4EfC0tKSRSKYIOLEFiaECOHONrdApYwrz9CJX/bxERZTeGtxwSEBgFv3cR6i5Gply+fAne3hvRt68b+vd3V3rP0bEJunTpBi2t3PmomJqawtTUNMvbmZtbwNzcIgdKRF+SyaRIPUZBoZBAKpXC2Fgfenp6OXrsxNAAJH58laPHICLK6xjeCLt2bUOBAgXRu3f/dN8vX76i0uvLly9h48a18PN7AX39fGjYsDE8PEYgX77Pt7Ru376JYcMGYeHC5Thy5CCuXvVF/vxGGDRoKJo1a4E9e3Zixw5vxMXFoUGDRhg5cix0dHQApL1t+uHDe3Tp0hZ//DENDx8+wKlTJ6Crq4OmTZ0waNAQMVTytmnukUiAj6GxSEr+PF2OoEhCVGQ8Zm28jsi4nJnfrpqtOXq1LJ8j+yYi0jQMbz+55ORkPHhwDw0bNs5U69q5c6cxefJ4tGzZBv37uyM0NASrVv2JqKhITJ06W2ndBQvmoGXL1mjbtj0OHTqAGTMm4cWLZ3j1yg+//z4O79+/w/Lli1GkSFH06tUvw+OuWbMS9eo1wPTps/HgwX1s2LAGlpaWaN++83edP6kmKVmOhMTP4Q2CAklyBfyDohASmTNzvVmaZ+02OhHRj4zh7ScXGRmBxMTENLccBUEQJyIGAKlUColEghUrlsLRsSm8vP4Q3ytQoCB+/304evcegFKlSovLGzVqjL593QAA5cpVxIUL53D69Ens3n1QDIp37tzCuXOnvxneypeviBEjfgcA2NvXxu3bN3Hu3FmGNyIi+ulwnjcCkHai1fPnz6Bhw9rinyVL5sPf/w0+fvwAR8emSE5OFv9UrVoNUqkUT58+VtqHvX0t8d+GhoYwMTFFlSrVlFr4ihUrjqCgwG+Wr2bN2kqvS5QoheDgb29HRET0o2HL20/OyMgYOjo6aQJU9eo1sW7dFgDA2LEjAQCfPn0CAIwfPzrdfQUGflR6nT9/fqXX2traaUaRamlpITEx8Zvl/HI7bW3tTG1HRET0o2F4+8lpaWmhUqXKuHXrBuRyOWQyGQDAyMgIRkafO4hra2v/f5kxAMDTcwwqVKiYZl8FCxbKpVITERH9vHjblODs7IKQkGB4e2/McL3ixUvA3NwC79+/g61t+TR/GN6IiIhyHlvecoilRf5vr5RHjlenzq9wde2DdetW4fnzp3B0bIaCBQsiOjoa9+7dQVhYKPT1DSCRSDBkiCemTp2A+Pg4ODj8inz58uHjxw+4cuUSBg70gJVV8Ww8KyIiIvoSw1s2UygEyOUKjHapnuvHlssVKs8AP2jQENjZVcG+fbuxaNEcREdHw8jIGDY2tvDymoQmTZoB+Dxpb/78hti8eQNOnToOAChc+BfUqlUHZmYFsu1ciIiIKH0SQRD4vJevkMsVCAuLSfe9pKREhIZ+QIECv0BbW0fpPU14ML2WlhTJyTkzoerP7kevWy0tKfwDo1LN85aM6KhgbDkTmGPzvDWoWhSjXWsgYP3oXH/Cgk7hkrDsvwDh4TE/5M9VS0sKU1ODH/b81OVnqVd1/L6TyaQwMsr3Q9atmZlBpp6Nzpa3HJCVEEVERKSJpFIJTEz0MxU2sptCIaSZ4upnwvBGREREWSaVSiCTSbFg2y0EBEbl2nEtLfJjtEt1tdzhyisY3oiIiEhlAYFR8HsXoe5i/FQY3oiIiEjjSKUSaGnl7i3bvNItiuGNiIiINIZJfl0ICgUMDfVy/dgKuRzhn+LUHuAY3oiIiHKIOjrzA3mnhSgnGObThkQqRdCBJUgMDci14+oUsIR5+xGQSiVqr1uGNyIiomwmkUggKBQwMsqnluPnlRainJQYGpDrUwflFQxvRERE2UwqlaildQjIWy1ElDMY3oiIiHLIz9w6RDmH4S0HaMITFgBAIgH4fA0iIiLNwvCWzaRSCUxN8kEqk+X6sTPbx0EikQBC2o60ly/7Ys+enXj8+CGioqJhZGSEcuXKo0WLlmjSpBmk0u/veCsInx87lpFjxw5j1qypOHLkNExMTDK97/XrV2Pnzq3w8bn41XVu376JYcMGpfvekSOnMXHiGOjr62PevCWZPq6qOndug48fP2S4Tt++bujf3z3Hy5KR58+fom9fFyxbtgrVqtVQa1ko56hrlnze1iPKOoa3bCaVSiCVydQ2CkZbW/bNcJQi6VMghOQkAMCazVuwdc/fqOdQG8MHuqGAmSnCP33CxSvXMGXKROgLiahZvdp3lVGipQ1tE4tvrufg8CtWrdoIQ0PDLO2/TZv2qFPn10ytO378ZFhZlVBaZmhoiFGjvHLtl9isWfORmJgkvp4wYTQqVaqCbt1cxWXm5ua5Uhb6eamzY/3P0KmeKCcwvOUQdfVzCAyNQVxCxg8H19fTRgFjPQjJSRCSEnDl5i1s3fM3+jh3Qd9uXZXWbVjLHp1bNodMSwtCUkJOFl1kamoKU1PTLG9nbm4Bc/Nvh0MAKFWqNGxty6dZXrJkqSwfV1XW1rZKr7W1dWBmZoaKFSvlWhmI1NWxnp3qiVTH8PaDSUxWICFRnuE62lrKt3R3HzqCAqam6NmlU7rrl7Mum2bZlZu3sHn33/B78wb59PTQwKE2fuvTC/n0Pk+aeOffhxjxxxTMnzQBR0+fxbXbt5E/f354DPFE48bNsWfPTuzY4Y24uDg0aNAII0eOhY6ODoC0t00/fHiPLl3a4o8/puHhwwc4deoEdHV10LSpEwYNGgItrc8f48zcNv2WIUMGKt02TdnnqlUbsWDBbDx79gRFihTFkCGeqFXLQWnbY8cOY9eubfD3fwsjI2M4ObXGgAGDIFPxFvrMmVPw5MkjeHvvFpdFRUXByakRxo+fjJYt2wD4fPu1Tp1fUbx4SWzfvgXR0VGoVq0GxoyZqBSCo6KisHr1Cly8eA6RkZEoWbI0Bg0agpo1aysdd9Omddi3bw/i4mJhb18b7dun/7mgHws71hNpDvXMHkh5RrJcjn+fPEW1ShWhlcmQcf7yFYyfPRelilthxtjfMahXT1y8eh3zVvyVZt1Fq9eipFUxTB/7OyrY2GDq1D+wcuUyXL9+Bb//Pg4DBrjjxImj2Llz6zePu2bNSkilUkyfPhvt2nXCzp1bceTIgayeMoDP/e6Sk5PFPwrF1281JycnY9q0iWjZsg1mzVoAU1MzTJw4BhERn8R1du7cirlzZ6BmTQfMn78ELi698fffu7BmzUqVypdVly5dgK/vBYwcORbDh4/GnTu3sWTJPPH9pKQkeHp64PLli3Bz+w1z5ixCyZIl8fvvw+Hn90Jcb+/eXVi3bhWaN2+JGTPmoUiRopgzZ3qunAMREWUOW95+cpFRUUhMSoJ5wQJKywVBgDxVoJFKJJBKpRAEAX9t8kajunUwxmOw+H4BUxOMnTEbvbp0RkmrYuLyhnUc0Me5CwCgfPkKuHDlKk6fPonduw+KLWZ37tzCuXOn0atXvwzLWr58RYwY8TsAwN6+Nm7fvolz586iffvOWT5vd/c+Sq9bt24HL68/0l03KSkJgwYNgYPD5/50VlbF0aVLW1y9ehnNm7dEbGwM1q9fgx49esHd3QNaWlJUr14T2tpaWL58MXr06AljY5MslzGr5sxZJLZefvjwHt7eG6FQKCCVSnHq1HE8f/4UmzbtEG8N16rlAH9/f2zatA7Tp8+BXC6Ht/cmNG/eEh4ew8V1wsPDcPLksRwvPxERZQ7DG30mUZ7a5J8rVzF5/iLxdQen5hgxcAD837/Hx+BgDOnfB8ny/27PVqlQHlKJBE9f+CmFtxqV7cR/GxoYwNTUFFWqVBODGwAUK1Ycd+7c+mYRv7y9V6JEKdy+fSPz55jKxIlTUaJESfG1icnX+9hJpVLUqFFLfP3LL0Wgq6uLoKAgAMCDB/cRFxeLRo0aIzk5GYAUyckK1KhRCwkJCXj50g9Vq1ZXqZyZVaVKNTG4AZ/rJjk5GeHhYShQoCCuX7+K0qXLoFgxq/+X8TN7+1o4deo4ACA4OAghIcGoX7+R0r4bNWrM8EZElIcwvP3kjPLnh462NoJDQ5WWV7erhNXz5wAAxs+aKy6PiIwCAEycMz/d/QV9sR9DAwOl11pa2mlGkWppaSExMfGbZf1yO21t7Uxtl54SJUqmO2AhPbq6utDW1k7n2J8HcKTcPu3Xz/XLTQEAQUGBKpUxK9KrGwBi/UREfMKzZ0/RsGHtNNum9MkLCQkBgDSDRUxNC6TZhoiI1Ifh7SenJZOhoq0Nbt9/ALlcLv4iz29oCNsynwOBdqpWsvz/Dwkj3PqnO5ChoFnWR4lquvz5jQAAM2fOh4WFBWQyqdJ0Lb/8UkSl/ero6CApSXnkcFRUpEr7MjIyRunSZTFuXPq3hgGgYMGCAIDw8HCl5eHhoemtTtlMXZN7q+OYRPR9GN4IXdu2htfMOdi6dz96d824/1hxy6IoVKAA3gcGokPLFrlUwrytYkU76OnpITg4EA0aNIKW1ufbpt+rUCFzBAcHIjY2Fvr6+gCA69evqrSvGjVq4soVXxQsWAgFCxb66vEKFCiICxfOoUGD/26dnjt3RqVjUuZJpRKYmOirZaJcItI8eS68+fn5YcaMGbhz5w4MDAzQrl07jBgxQqk/T3rCw8OxePFiXLhwAZ8+fYKlpSVcXFzQvXv3XCq5Mp0ClhpzPIca1eHSsT027NiFF69eo9GvdVDA1BQxMbG4//gxwj59gn6+zxN4SiQSePTtjemLlyI+PgG1a1RDPl1dfAwOwdVbt+Dm0gPFiqrW0qSp8ufPj/79B2HlyuUICgpCjRr2ACR4/z4AFy9ewMyZ86D3/ylUsqJBA0esX78as2dPQ9u27fHq1UscPnxApTK2aNEKBw/uw5Ah7uje3RXFilkhOjoaz58/FQdkyGQyuLr2wdKlC2BmVgD29rVw/frVTPVHpO8jlUogk0mxYNstBARG5eqxq9mao1fLzHUh0FTqaNVkiyblpDwV3iIiItC7d2+UKFECy5cvR2BgIObMmYP4+HhMmjQpw22HDx+Oly9fYuTIkfjll19w4cIFTJkyBTKZDF27ds1w2+ykUAhQyOUwbz8i146ZQi6Xq9ziM7CnCyqVs8X+4yexZPU6RMfGwsjQENalS2HMkMFo/Gtdcd1GdR1gaKCPrX/vg8+FCwCAwoXMUbNaFZiaGGfLuWia7t1dUahQIezatQ179+6GlpYMRYtaok6dekqDM7KiZMlSmDBhCjZtWgcvr1Gws6uCSZNmoG/fHlnel46ODpYt+wsbNqzBli0bEBoaAmNjE1hb26BDhy7iep07OyM6Ogr79u3B/v17UKNGTYwdOxGjRg1V6RwoawICo+D3LiJXj2lpnrUnmWgatmrSj0giCHnn0eSrV6/GqlWrcO7cOfGZlrt27cLUqVNx7tw5WFikP3t+cHAwfv31V8yePRsdO3YUl7u6ukImk2Hz5s0qlUcuVyAsLCbd95KSEhEa+gEFCvwCbW3lVsGsfMuTyaQIDI1BYjbcZktOViAxKeMJegHAUF8HhQvoIzEkINeemgAAEm1d6BS0zJZbinlZdt02zau0tKTwD4z6bzJoIRnRUcHYciYQIZEZP91DVQ2qFsVo1xoIWD861yeS1SlcEpb9FyA8PCbHfq5aWlKYmhpgxKLzuR7e1FW3uVGvwH91m9utmiktmj/qZxZQ3+f2R/7MmpkZZOqLRp5qebtw4QIcHByUHkbu5OSEyZMnw9fXVymYpZYy9UH+/PmVlhsaGiI2NjbHyvs1WX3YclxC8jefikBERKrL7VbNH71Fk9QrT4W3ly9folMn5UfxGBkZoVChQnj58uVXt/vll1/w66+/YtWqVShZsiQKFy6MCxcuwNfXFwsWLPiuMmlppZ+AFYrv788g+Um7REgkQN5p781eKT/TH/Ucf9bPLIAcve32M9/Sy+lzZ91q7v7zqrxw3nkqvEVGRsLIyCjNcmNjY0REZPyNafny5fD09ESrVq0AfJ67auLEiWjevLnK5ZFKJTA1NUj3vfh4GUJCpJDJJF8NeJS+vPDBz2k/wzn+bIyM8qm7CD8k1mvOYd3mjLxQr3kqvKlKEASMGzcOr1+/xsKFC1GoUCFcvnwZs2bNgrGxsRjoskqhEBAZmf5t18TEBCgUCsjlgsr3viWSn/OXvFyu+CFbpYD/fqY/6jn+rJ9ZAIiMjFOavy87yWTSPPELQR1ysl4B1i3rNvvlZL0aGeXTvD5vRkZGiIpK26E0IiICxsZfH8V4/vx5nDhxAocOHYKNjQ0AoFatWggNDcWcOXNUDm8AvhrM5PLPv5m/Z7zHj/jLPTN+5PNOObcf9RzTPy8hg/d+HHK54oceiKIurNecw7rNGXmhXvPUV+hSpUql6dsWFRWF4OBglCpV6qvbvXjxAjKZDNbW1krLy5Urh6CgIMTFxWV7WVOeRJDyiCSin5aQjGS5AlFxHHRDRJQb8lTLW/369bFq1Sqlvm8nTpyAVCpF3bp1v7pd0aJFIZfL8fTpU9ja2orLHz58iAIFCiBfvuxv1pVKZciXzxDR0Z8fJaSjowuJCr25FQoJBEUSIOReilfIJUhMTECSXAEhC6Niv5dErgASE8RWyx+VQiH5oc/xv8+sHBCSERcbgbt+0UhM/nHPmYgoL8lT4a1bt27w9vaGh4cH3N3dERgYiHnz5qFbt25Kc7z17t0b79+/h4+PD4DPoa9IkSIYNmwYPDw8YG5ujkuXLmH//v0YOjTnJhc1MjIDADHAqUIqlSIqMh5JOdgv4UvJCTIgWRfy6HAI8pyZlys9EpkWZHIBCsWP3YwvlUp/6HNM/ZlNlitw1y8aFx/m7lMBiIh+ZnkqvBkbG2Pz5s2YPn06PDw8YGBggM6dO8PT01Npvc8DBf67RWNoaIhNmzZh8eLFWLBgAaKiomBpaQkvLy+4urrmWHklEgmMjQsgf35TyFUIQTKZBMbG+pi18Tr8g3Lvl599OQv0a1sKH/+ei6SQd7l2XO2CRVG481hERMT+sC1TKT/TH/UcU39m3wZGISpOzhY3IqJclqfCGwCULl0amzZtynAdb2/vNMuKFy+OJUuW5EyhvkEqlUIqzfjZq+nR0pJCT08PkXGKHJuZPj2xiYCenh60EqKgiAnNteNq5TeCnp4e4uJUf4xXXpfyM/1RzzH1ZzY0Kvc+s0RE9J88NWCBiIiIiDLG8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQahOGNiIiISIMwvBERERFpEIY3IiIiIg3C8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEG+e7wFhQUhCdPniA2NjY7ykNEREREGVA5vJ0+fRotWrRAgwYN0KFDB9y7dw8AEBYWhvbt2+P06dPZVkgiIiIi+kyl8Hb27FkMHToUpqam8PDwgCAI4ntmZmawsLDA3r17s62QRERERPSZSuFtxYoVqFGjBnbs2AEXF5c071epUgWPHz/+7sIRERERkTKVwtvz58/h5OT01fcLFiyI0NBQlQtFREREROlTKbzly5cPcXFxX33f398fJiYmKhXIz88Pffv2RZUqVVC3bl3MmzcPiYmJmdo2MDAQY8eORe3atWFnZwcnJyccOnRIpXIQERER5UVaqmxUq1YtHDhwAL17907zXnBwMHbv3o1GjRpleb8RERHo3bs3SpQogeXLlyMwMBBz5sxBfHw8Jk2alOG2QUFBcHZ2RsmSJTF9+nQYGhri+fPnmQ5+RERERJpApfA2YsQIODs7o3PnzmjRogUkEgkuXbqEq1evYteuXRAEAR4eHlne786dOxETE4M///xTbLmTy+WYOnUq3N3dYWFh8dVt58+fj8KFC2PdunWQyWQAAAcHB1VOj4iIiCjPUum2aalSpbB9+3aYmJhg6dKlEAQB69evx+rVq2FtbY3t27fD0tIyy/u9cOECHBwclG65Ojk5QaFQwNfX96vbRUdH4/jx4+jRo4cY3IjUSSaTQksrd/9IpRJ1nzYREeUClVreAKBs2bLYtGkTIiIi8ObNGwiCgGLFisHMzEzlwrx8+RKdOnVSWmZkZIRChQrh5cuXX93u4cOHSEpKgpaWFlxdXXHnzh2YmJigffv2GDFiBLS1tVUuk5ZWzj2EQib7OR9wkRvnLZFI1BJmZDIJBIUCRkb5cv3YgkKOiMgEpal7stvP+pkFcvbcWa+au/+8jHWbM/LCeasc3lIYGxvDzs4uO8qCyMhIGBkZpXuMiIiIr24XEhICAJg4cSK6du2KIUOG4P79+1i2bBmkUilGjRqlUnmkUglMTQ1U2pa+LjeCjUIhqLUlKujAEiSGBuTa8XQKWMK8/QiYmOjn2jF/NuoI5D8D1mvOYd3mjLxQryqFtwMHDmRqvfbt26uy+yxTKBQAgDp16sDLywsAULt2bcTExGDDhg3w8PCAnp6eCvsVEBmZc4/9ksmkeeJDkNsiI+MglytybP8p9bpg2y0EBEbl2HHSU83WHL1alkdiaAASP77K1WMDuVe3P6OcrFvWKz+zOYF1mzNysl6NjPJlqmVPpfCWEpDSI5H819qR1fBmZGSEqKi0v2wjIiJgbGyc4XbA58CWmoODA1atWoU3b97AxsYmS2VJkZyccx/8n5VcrsiVeg0IjILfu6+32OYES3PDXD3el3Krbn9GrNucwXrNOazbnJEX6lWl8HbmzJk0yxQKBQICArBjxw68f/8ec+fOzfJ+S5UqlaZvW1RUFIKDg1GqVKmvblemTJkM95uQkJDlshARERHlRSr1uitatGiaP8WKFYODgwOWLVsGMzMzbN26Ncv7rV+/Pi5fvozIyEhx2YkTJyCVSlG3bt0My2NtbY3Lly8rLb98+TL09PS+Ge6IiIiINEWODJlo2LAhjh07luXtunXrBgMDA3h4eODSpUvYu3cv5s2bh27duinN8da7d280bdpUaVtPT0+cPXsWM2fOhK+vL1atWoUNGzagT58+0NdnJ24iIiL6MXz3aNP0+Pv7q/RkA2NjY2zevBnTp0+Hh4cHDAwM0LlzZ3h6eiqtp1AoIJfLlZY5Ojpi0aJFWLlyJXbs2AFzc3MMHToUAwcO/K5zISIiIspLVApvN27cSHd5ZGQkbt68CW9vbzRu3FilApUuXRqbNm3KcB1vb+90l7ds2RItW7ZU6bhEREREmkCl8NazZ0+lUaUpBEGATCZDixYtMHHixO8uHBEREREpUym8bdmyJc0yiUQCIyMjFC1aFIaG6p0ugYiIiOhHpVJ4q1mzZnaXg4iIiIgyQf0P6CIiIiKiTMtUy5ujo2O6fdwyIpFIcPr0aZUKRURERETpy1R4q1mzZpbDGxERERFlv0yFtzlz5uR0OYiIiIgoE9jnjYiIiEiDfNcTFpKSkvDy5UtERUVBEIQ079vb23/P7omIiIjoCyqFN4VCgYULF2L79u2Ij4//6nqPHz9WuWBERERElJZK4W3VqlVYv349nJ2dUb16dYwZMwajR4+GkZERtm/fDolEgt9//z27y0pERET001Opz9v+/fvh5OSEqVOnol69egCAChUqoGvXrti9ezckEgmuXr2arQUlIiIiIhXD28ePH1G7dm0AgI6ODgAgMTFRfN22bVscPHgwm4pIRERERClUCm8mJiaIjY0FABgYGMDQ0BD+/v5K60RGRn5/6YiIiIhIiUp93sqXL48HDx6Ir2vVqoXNmzejXLlyEAQBW7ZsgY2NTbYVkoiIiIg+U6nlrWvXrkhMTBRvlXp6eiIyMhKurq5wdXVFTEwMvLy8srWgRERERKRiy1vjxo3RuHFj8XWZMmVw+vRpXLt2DTKZDFWrVoWJiUl2lZGIiIiI/k+l8CYIQppnnebPnx9NmjTJlkIRERERUfpUum1ar149zJgxA7dv387u8hARERFRBlRqeatZsyb27t2Lbdu2wcLCAk5OTnBycoKdnV12l4+IiIiIUlEpvC1atAjx8fE4d+4cjh8/jh07dmDTpk0oWrQoWrZsCScnJ5QrVy67y0pERET001P5wfR6enpii1tsbCzOnj2LY8eOYdOmTVi7di2KFy+OEydOZGdZiYiIiH56KvV5+5K+vj5at26N+fPnY8yYMdDX18ebN2+yY9dERERElIrKLW8p4uLicPbsWRw/fhwXL15EYmIirKys4OTklB3lIyIiIqJUVApvCQkJOH/+PI4dO4YLFy4gLi4ORYsWRc+ePdGyZUuUL18+u8tJRERERFAxvNWuXRvx8fEwNzdH165d0bJlS1SuXDm7y0ZEREREX1ApvHXs2BFOTk6oUaNGdpeHiIiIiDKgUnj7448/srscRERERJQJ2TLalIiIiIhyB8MbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIg3zXExbu3r2La9euITQ0FD169ECJEiUQFxeHly9fokSJEjAwMMiuchIRERERVAxviYmJGDlyJM6cOQNBECCRSNCoUSOUKFECUqkU/fr1Q58+fTB48ODsLi8RERHRT02l26ZLly7F+fPnMWXKFJw4cQKCIIjv6erqokWLFjhz5ky2FZKIiIiIPlMpvB09ehTdunWDs7MzjI2N07xfunRp+Pv7f3fhiIiIiEiZSuEtNDQUNjY2X31fJpMhPj5e5UIRERERUfpUCm+//PILXr58+dX3b9++DSsrK5ULRURERETpUym8tW7dGjt37sSdO3fEZRKJBACwe/duHD9+HO3bt8+WAhIRERHRf1QabTpo0CDcu3cPrq6uKFWqFCQSCWbPno2IiAh8/PgRDRo0QJ8+fbK5qERERESkUnjT0dHBunXrcOjQIZw8eRIKhQKJiYmwsbHBiBEj0K5dO7EljoiIiIiyT5bDW3x8PBYvXoxatWqhXbt2aNeuXU6Ui4iIiIjSkeU+b3p6eti1axdCQ0NzojxERERElAGVBixUqFABz549y+6yEBEREdE3qBTexo8fj2PHjmHPnj1ITk7O7jIRERER0VeoNGDBy8sLEokEkyZNwowZM2BhYQFdXV2ldSQSCQ4dOpQthSQiIiKiz1QKbyYmJjAxMUHJkiWzuzxERERElAGVwpu3t3d2l4OIiIiIMkGlPm9EREREpB4qtbwBgFwux6FDh3D+/Hm8f/8eAFCkSBE0atQIbdq0gUwmU2m/fn5+mDFjBu7cuQMDAwO0a9cOI0aMgI6OTqb3sWnTJsyePRsNGzbE6tWrVSoHERERUV6kUniLiopC//798eDBAxgYGKBYsWIAgMuXL+PUqVPYsWMH1q9fD0NDwyztNyIiAr1790aJEiWwfPlyBAYGYs6cOYiPj8ekSZMytY/g4GCsWLECBQoUyPJ5EREREeV1KoW3xYsX4+HDh5g4cSK6du0KbW1tAEBSUhL27NmDmTNnYvHixfjjjz+ytN+dO3ciJiYGf/75J0xMTAB8buGbOnUq3N3dYWFh8c19zJ8/H46OjmJrIBEREdGPRKU+bz4+PujevTtcXFzE4AYA2tra6NGjB7p3746TJ09meb8XLlyAg4ODGNwAwMnJCQqFAr6+vt/c/ubNmzh9+jRGjRqV5WMTERERaQKVWt4+ffqU4TQhJUuWRERERJb3+/LlS3Tq1ElpmZGREQoVKoSXL19muK1cLsf06dMxaNAgmJubZ/nYX6OllXNjOmSyn3O8SE6f989arwDrNifl5LmzXjV3/3kZ6zZn5IXzVim8FS9eHGfPnoWLi0u67589exZWVlZZ3m9kZCSMjIzSLDc2Nv5mGNy+fTvi4uLQp0+fLB/3a6RSCUxNDbJtf/SZkVE+dRfhh8W6zTms25zBes05rNuckRfqVaXw1r17d0yfPh1ubm7iAAMAePXqFby9vXH58uUs93f7HqGhoVi2bBnmzp2bpVGp36JQCIiMjM22/X1JJpPmiQ9BbouMjINcrsix/f+s9QqwbnNSTtYt65Wf2ZzAus0ZOVmvRkb5MtWyp1J4c3FxQVhYGNasWYNLly4p71BLCx4eHujRo0eW92tkZISoqKg0yyMiImBsbPzV7ZYuXQobGxvUqFEDkZGRAIDk5GQkJycjMjIS+vr60NJSbVaU5OSc++D/rORyBes1h7Bucw7rNmewXnMO6zZn5IV6VXmet6FDh8LFxQVXrlzBu3fvAABFixaFg4MDzMzMVNpnqVKl0vRti4qKQnBwMEqVKvXV7V69eoUbN27A3t4+zXv29vZYu3Yt6tevr1KZiIiIiPISlcMbAJiZmaFVq1bZVRbUr18fq1atUur7duLECUilUtStW/er240fP15scUsxa9Ys6OnpYeTIkbCxscm2MhIRERGpk0rh7fLly7h69SpGjhyZ7vuLFy9G7dq14eDgkKX9duvWDd7e3vDw8IC7uzsCAwMxb948dOvWTWmOt969e+P9+/fw8fEBAJQrVy7NvoyMjKCvr49atWplqQxEREREeZlK411XrlyJDx8+fPX9wMBA/PXXX1ner7GxMTZv3gyZTAYPDw8sXLgQnTt3hpeXl9J6CoUCcrk8y/snIiIi0nQqtbw9e/YMLVq0+Or7lSpVwrlz51QqUOnSpbFp06YM1/H29v7mfjKzDhEREZGmUanlLTExEUlJSRm+Hx8fr3KhiIiIiCh9KoW3smXLiv3NviQIAk6dOoXSpUt/V8GIiIiIKC2Vwpurqytu376NYcOG4enTp+Kcak+ePMHw4cNx9+5d9OzZM7vLSkRERPTTU6nPW7t27eDv74+VK1fCx8cHUunnDKhQKCCRSDB48GB06NAhWwtKRERERN8xz9uQIUPQtm1b+Pj4wN/fHwBgZWWFJk2aqPRcUyIiIiL6tu+apNfKygr9+/fPrrIQERER0Td8V3hL4efnhxMnToiPserYsSMMDQ2zY9dERERElEqmw9vWrVvh7e2NHTt2KD279OzZsxg+fLjS1CHe3t7YtWuXys84JSIiIqL0ZXq06dmzZ1GsWDGlQJacnIyJEydCJpNh9uzZOHz4MEaNGoX3799j1apVOVJgIiIiop9ZpsPbixcvUKVKFaVl165dQ1hYGHr37o0OHTqgbNmycHNzQ4sWLfDPP/9kd1mJiIiIfnqZDm+fPn1C4cKFlZZduXIFEokETZs2VVperVq1DJ99SkRERESqyXR4K1iwIEJCQpSW3bx5E3p6erC1tVVarqOjA21t7ewpIRERERGJMh3eKlasiP379yM6OhoA8Pz5czx48AD16tWDlpbyuIeXL1+maaUjIiIiou+X6dGmHh4e6Ny5M5o3b44yZcrg4cOHkEgkGDhwYJp1fXx8ULt27WwtKBERERFloeXNxsYGmzdvRoUKFRAUFITKlStjzZo1qFixotJ6165dQ758+dCiRYtsLywRERHRzy5Lk/RWq1YNa9asyXCdWrVq4fDhw99VKCIiIiJKX6Zb3oiIiIhI/RjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQahOGNiIiISIMwvBERERFpEIY3IiIiIg3C8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEG01F2AL/n5+WHGjBm4c+cODAwM0K5dO4wYMQI6Ojpf3SYoKAibNm2Cr68v3r59i/z588Pe3h4jR45E0aJFc7H0RERERDkrT4W3iIgI9O7dGyVKlMDy5csRGBiIOXPmID4+HpMmTfrqdg8fPoSPjw86deqEypUrIzw8HH/99Re6dOmCI0eOwMzMLBfPgoiIiCjn5KnwtnPnTsTExODPP/+EiYkJAEAul2Pq1Klwd3eHhYVFuttVr14dx48fh5bWf6dTrVo1NGzYEAcOHEC/fv1yo/hEREREOS5P9Xm7cOECHBwcxOAGAE5OTlAoFPD19f3qdkZGRkrBDQAKFy4MMzMzBAUF5VRxiYiIiHJdnmp5e/nyJTp16qS0zMjICIUKFcLLly+ztK9Xr14hNDQUpUuX/q4yaWnlXL6VyfJUds41OX3eP2u9AqzbnJST58561dz952Ws25yRF847T4W3yMhIGBkZpVlubGyMiIiITO9HEATMmDED5ubmaNWqlcrlkUolMDU1UHl7Sp+RUT51F+GHxbrNOazbnMF6zTms25yRF+o1T4W37LJ8+XJcvXoV69atg76+vsr7USgEREbGZmPJlMlk0jzxIchtkZFxkMsVObb/n7VeAdZtTsrJumW98jObE1i3OSMn69XIKF+mWvbyVHgzMjJCVFRUmuUREREwNjbO1D52796NFStWYObMmXBwcPjuMiUn59wH/2cllytYrzmEdZtzWLc5g/Wac1i3OSMv1Kv6b9ymUqpUqTR926KiohAcHIxSpUp9c3sfHx9MmTIFw4YNQ+fOnXOqmERERERqk6fCW/369XH58mVERkaKy06cOAGpVIq6detmuO21a9cwcuRIdOnSBR4eHjldVCIiIiK1yFPhrVu3bjAwMICHhwcuXbqEvXv3Yt68eejWrZvSHG+9e/dG06ZNxdd+fn7w8PBAiRIl0K5dO9y9e1f88/btW3WcChEREVGOyFN93oyNjbF582ZMnz4dHh4eMDAwQOfOneHp6am0nkKhgFwuF1/fu3cPUVFRiIqKQvfu3ZXW7dChA+bMmZMr5SciIiLKaXkqvAFA6dKlsWnTpgzX8fb2VnrdsWNHdOzYMQdLRURERJQ35KnbpkRERESUMYY3IiIiIg3C8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQahOGNiIiISIMwvBERERFpEIY3IiIiIg3C8EZERESkQRjeiIiIiDQIwxsRERGRBmF4IyIiItIgDG9EREREGoThjYiIiEiDMLwRERERaRCGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQahOGNiIiISIMwvBERERFpEIY3IiIiIg2S58Kbn58f+vbtiypVqqBu3bqYN28eEhMTv7mdIAhYs2YNGjZsCDs7Ozg7O+Pu3bs5X2AiIiKiXJSnwltERAR69+6NpKQkLF++HJ6enti9ezfmzJnzzW3Xrl2LZcuWoU+fPli9ejUKFSqEfv36wd/fPxdKTkRERJQ7tNRdgNR27tyJmJgY/PnnnzAxMQEAyOVyTJ06Fe7u7rCwsEh3u4SEBKxevRr9+vVDnz59AADVq1dHixYtsH79ekyZMiV3ToCIiIgoh+WplrcLFy7AwcFBDG4A4OTkBIVCAV9f369ud/v2bURHR8PJyUlcpqOjg6ZNm+LChQs5WWQiIiKiXCURBEFQdyFSODg4oFOnThg9erTS8nr16qFdu3ZplqfYtm0bpk2bhvv370NXV1dcvnv3bkyaNAl3796Fnp5elssjCAIUipyrHokEkEql+BSVgGS5IseO8yVdHRny6+tAHhMBQZ6ca8eVyLQgMzCGQqFATn7q1FWvAOs2p6irXoHcqVt+ZnPwOPzM5txxfrK6zY16lUolkEgk31wvT902jYyMhJGRUZrlxsbGiIiIyHA7HR0dpeAGAEZGRhAEARERESqFN4lEApns25X4vUzy6357pRwgMzBWy3Gl0txp8FVXvQKs25yirnoFcqdu+ZnNOfzM5pyfrW5zq14zLIO6C0BEREREmZenwpuRkRGioqLSLI+IiICx8dcTtpGRERITE5GQkKC0PDIyEhKJJMNtiYiIiDRJngpvpUqVwsuXL5WWRUVFITg4GKVKlcpwOwB49eqV0vKXL1+iSJEiKt0yJSIiIsqL8lR4q1+/Pi5fvozIyEhx2YkTJyCVSlG3bt2vbletWjUYGhri+PHj4rKkpCScOnUK9evXz9EyExEREeWmPDVgoVu3bvD29oaHhwfc3d0RGBiIefPmoVu3bkpzvPXu3Rvv37+Hj48PAEBXVxfu7u5Yvnw5zMzMYG1tjR07duDTp0/o37+/uk6HiIiIKNvlqfBmbGyMzZs3Y/r06fDw8ICBgQE6d+4MT09PpfUUCgXkcrnSMjc3NwiCgA0bNiAsLAzlypXD+vXrUaxYsdw8BSIiIqIclafmeSMiIiKijOWpPm9ERERElDGGNyIiIiINwvBGREREpEEY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2I6AfD6TuJfmwMbz8AhUKh9JoXbqKfU8qTZyQSiZpLQkQ5ieFNw8nlckiln3+Mr1+/RkJCAi/c2SR1CI6Pj1djSX58/MLxfRQKBY4ePYpz586Jy4YNG4aLFy+qsVQ/tqSkJHUXgX5iDG8aTC6XQyaTAQAmTZqEefPm4cCBA2la4ijrBEEQQ/A///yDZcuW4cqVK2ou1Y/jy2cTp9Q1Q5xqJBIJnj17hqFDh+Lo0aMYNGgQfH19YWZmpu6iaTyFQoFz587Bx8dHXDZ79mxcvXpVjaX6MfD/u+ry1IPpKWtSgtuIESNw//59DBs2DA4ODmJLHKkuJUzs27cPM2bMQLt27fhNO5uk/tKxfft2+Pv7Q0dHB3Xq1EGtWrXUXDrNJJFI4OnpiaCgIIwfPx56enpYs2YNKlSooO6iabyEhAScPHkSt2/fRnx8PI4ePYpbt26hc+fO6i6aRkv9Bfnhw4cIDQ1FREQE6tevDwMDA2hpaSmtQ8oY3jTc4cOHcevWLcyfPx81a9ZkcPsOX14obty4gXnz5mHo0KHo1KkTjIyM1Fi6H4MgCGJwGzZsGB48eAAzMzNIpVKsWbMGAwcOROfOnVGsWDE1l1QzyWQyJCQkAADevHmDChUqQE9PT82l0kwKhQLJycnIly8fxo4dC3d3d0ybNg0ymQwbNmxA2bJl1V1EjZZyrd27dy8WLFgALS0tREdHo0CBAujbty9atGiBAgUKqLmUeRd/02uIuLg4PHv2LM3yN2/eQF9fH5UqVVIKbl82R7N5+tu+/IZ37949mJqaomnTpgxu2SSljjds2ID79+9j/vz52Lx5M/bs2QN3d3esXr0aT58+5a1/FfXq1Qv79u1D06ZNMW3aNBw5cgSxsbHqLpbGSUhIQP/+/XHmzBnExsbC1NQUZmZmiI2NhYGBAZ4+fSquy8+q6nx9fTFz5kwMGjQIa9euxe3bt2Fvb4/58+fj8OHDabpX0H8Y3jRAUlIS3N3dsX///jQXisjISMTExMDAwADAfxeS1P21YmNj2fScgblz52LhwoXi65Q6fPToEbS0tGBpaam0PEVgYGDuFfIH8/jxY1SpUgWVK1eGoaEhXr16hd27d8PJyQn16tVjC3ImpPeLzdraGuXLl8fs2bPRuHFjzJgxA8eOHRMH3MTHx+PJkye5XVSNk5SUhJCQEMyZM0fs2+bs7Iy//voLpqam2LBhA/bs2QMAkEql/HKsonv37qFixYpo2bIlbG1tIZFI8OnTJ1hYWKBu3bqQyWQMx1/BK6QG0NbWRu/evTFkyBBIpVK8f/9efK98+fKIj4/Hjh07kJycrPRL78mTJzh8+DAePXqkjmJrhKioKCgUCjRo0EBcllKH1atXh7+/vzhQIfVFOiAgAH/++afSN3DKHIVCgU+fPkGhUEBbWxuvXr2Cs7MzatWqhZkzZ0JXVxfLli3DvXv31F3UPCt1v8H9+/dj4cKFWLx4MW7evAng8zVjzpw5aNy4MWbOnIkDBw7g8ePHmDVrFnr27ImoqCh1Fj/PMzQ0xLZt22BlZYWJEyfi3Llz+PXXX1G/fn2sWLEC+vr62LhxoxjgJBIJEhIS8OTJEyQmJqq59HlTel82Hj58iNjYWBQqVAgAMGDAADx69AhLly5F2bJlcefOHTx48CC3i6oRGN7yuJSw0LhxYxgYGGDx4sUYMmQI/v33XwBA06ZNUbJkSaxduxZHjx4VtwsKCsKWLVvw6NEjWFlZqaXsmiB//vwYNWoUatSogfPnz2PatGnie9bW1ihcuDC2bt0q1rdEIkFSUhIuX76Mu3fvchDDN6Q3B6FUKkXRokXx6NEj3Lx5E926dYODgwOmT58OfX19+Pv749atW7hz5w6/dadDoVAoDVb666+/cPPmTTx8+BB9+vTByZMnAfwX4Jo1a4YpU6Zg6NChOHfuHDZs2ID8+fOr8xTytJRrrpGREVasWIHSpUtj4sSJuHjxIuLi4mBhYYE///wTBgYG2LRpE7Zv347AwEDMmDEDU6dOFfsc0mfPnz/Hx48fxc+sr68v7t+/DwCoWLEiEhIS8ObNGwwcOBAvXrzAqlWrYGtri/DwcGzevBnXr19HcnKyOk8hbxIoT0tOTlZ6vXbtWqFFixbCgAEDhHv37gmCIAgRERFC69atBQcHB6Fbt27CyJEjBWdnZ6FmzZrC48eP1VFsjaBQKMS/4+PjhQkTJgg1atQQZs+eLa6zdetWoW7duoKzs7Owf/9+4fz588Kff/4pVKlSRVi7dq26iq4RUn92IyIihKioKPH1x48fBUdHR8HGxkYYOnSokJiYKAiCIAQHBwteXl5Cy5YthYCAgFwvsyaZPn260KRJE+HmzZuCIAjC/PnzBRsbG8HGxkb4+++/ldY9dOiQsG/fPuHt27fqKKrGkMvlaZZFREQIrq6uQt26dYUzZ84IsbGxgiAIwocPH4Ru3boJNWvWFBwdHYW6desK9+/fz+0i52mhoaHC/PnzhS5dugifPn0SDh8+LNjZ2Qlnz54VBEEQbt26JVSoUEGoVauW0KhRI+HZs2eCIAhCYmKisG/fPqFx48bC6dOn1XkKeZZEEHizXhPs3bsXnTp1AgDs2rULGzduRNGiRTFs2DBUrlwZ0dHRYifw2NhY2NjYoGfPnihVqpSaS573BQcHo1ChQvjw4QPWr1+PU6dOoVmzZpg4cSKAz7elDhw4gGvXrkFbWxtWVlbo0qUL+vTpAyDtKFVSrpPJkyfj33//RWhoKPr16wdHR0dYWlri9OnTWLhwIWQyGdzd3REUFIS7d+/i2rVr2LJlC2xtbdV8FnnX8+fPMXv2bHTq1AmtWrXC+vXrsWjRIowbNw53797FkSNHsHDhQrRq1UrdRdVIf/zxB2rXri3WX2RkJDw8PPDq1StMmzYNDg4OyJcvH0JCQnDq1CkkJCTA0dERxYsXV3PJ8559+/Zh8+bNiI2Nxfv37zFlyhS0a9cO2trakEgkOHz4MH7//XfUq1cP7u7uMDAwwKVLl7By5UoMHjwYAwcOVPcp5E3qzY6UGdu3bxdq1qwpxMTEiMt27twpNG/eXOjXr59w9+5dQRCUW5JS/k0Zu3DhgtCoUSMhNDRUEITPLUJTpkwR6tWrJ0yfPl1cLzQ0VHj9+rXw4sUL4f379+Ly9L6p/+xSt7iNHz9eaNiwoTBz5kzB09NTsLW1FcaPHy+8fv1aEARBePz4sdCrVy+hdevWgpOTkzBy5Ejx2zd9XUhIiLB//34hKipK8PHxEapVqybs3btXEARBuH79umBjYyOUL19e2L17t5pLqnnCwsKE/v37C5UqVRJ8fHzE5V9rgaNvmzx5smBjYyM0atRIePr0qSAIn68TKb+njh8/LjRq1EioV6+eYG9vL7Rr107YuHGjuD2vs2mx5U0DnDt3DkOHDsXBgwdRunRpcXnqFjhPT09UrFhRjaXUTNu2bcOKFStw9uxZcT6swMBArFq1CmfOnFFqgfuSwBa3DEVHR2PlypWoU6cOHBwcIJPJsGPHDsyZMwfNmzeHu7u7+HkOCgqCgYEBtLW1oaOjo+aS5y0KhSLd0bfR0dEwNDTE+PHjER4ejgULFoijzl1cXBASEoJPnz7Bx8eHU91kIL3/x+/evcPixYtx8uRJLF68GE2aNAHwXwucv78/xo0bh0aNGvHzmoHk5GQIgoBZs2YhMTERDx48gI6ODubOnYvSpUuLj3eUSCT4+PEjoqKikJCQgAIFCuCXX34B8PXP/8+ONZLHpDcix9LSEnp6eggJCQHw3zP1nJ2d0bdvXwQFBWHatGmcAuAb0vueUqtWLcTFxYkdaOVyOSwsLDBo0CA0btwYZ8+exfTp09PdH4Pb1y1cuBC1atXCqVOnULBgQbGzcvfu3TF+/HicPHkSa9euFecuNDc3h4GBAX8RfiH1s4ufPXuGp0+f4vXr1wA+j4gUBAFhYWGIioqCtrY2AMDPzw9SqRQTJkzA8ePHGdwyoFAoxP/HqQcapHwhbtasGTw9PXH69GkA/w1iMDY2xuLFizlgKR2pr7NaWlrQ1tbG2LFjMXPmTPTu3RuJiYkYO3YsXrx4oTQViL6+PsqWLYuKFSuKwU34/wAnSotPWMhjUn7J7dixA3p6eqhRowYKFSqEwoUL4/r166hVq5Z4kQY+B7i4uDgcOXKEF+lvSLlIv3r1CmZmZjA0NBSHqKcEY4lEAkEQxAAnl8uxd+9eODk5oUaNGmoru6YpVaoU7Ozs8OTJE/EXXGJiInR0dODs7AwAmDdvHmJiYuDp6cm+melIPap0zJgxuH//Pt6/f4+CBQvC0dERv//+O3R1dWFnZ4dNmzZhzZo1KFWqFC5fvoxPnz6hQoUKfLbpN6QEgzlz5kBLSwuDBg2CoaEhgM8BbuTIkVAoFBg1ahSWLFmCRo0awcjICFu3bkVkZKTY0kmfpW7FfP/+PRITEyGVSsUw1qlTJygUCmzduhVeXl5YuHAhihcvjtOnT+PQoUOYMGECLCwsxP3xC/LX8bZpHnT+/HmMHTsWycnJkEgkkEqliIyMRL169VC3bl3UqFEDRkZGKFKkCLS0PufvyMhIhrdMuHjxIoYNGwYtLS2ULVsWlStXxu7du9G8eXMMHDgQVlZWSt/0AgMD8fr1az5zMwPp3dZQKBQ4ceIElixZguTkZOzevRsFCxYUAxwAbNmyBWvWrMHevXuVLtikbMKECfD19cXYsWOhq6uLmJgYjBs3Dg0aNMD8+fOhr68PLy8vnD17FoIgwNjYGMuXL0e5cuXUXfQ868tbpb169cKbN2/QrVs39OzZUwxwAPDgwQP89ttvSExMxNSpU9GiRQt1FFmjHDlyBCtXrkRUVBTCw8PRtWtXtGvXDpUrVwYA/P333/D29kZoaCgaN26MvXv3wsPDA4MHD1ZzyTUHw1sekN4vv5RJTJ89e4bXr1/jwIEDePToEQoUKIDQ0FAIgoAiRYqgSpUqmDNnDr+hZFJ4eDgePHiAt2/f4vXr17hz5w7evHkDhUKBpKQklChRAkWLFkWZMmVQrlw5pdF67HuRVurJYgMCAqCtrQ2pVIpChQpBoVDg1KlTWLx4MaRSKby9vdMEOH7pyJifnx9GjBgBNzc3tGjRAjo6Onj58iXatWuHVq1aYdKkSdDX1wcA3LlzBzKZDIULF4a5ubmaS553pf7Mpv78jRgxArdv30a3bt3Qq1cvpQA3cOBA3Lt3DzKZDKdOnVJ6j5QdPXoUEydORP/+/eHs7Ixdu3ZhzZo1qF+/Pvr164dq1aoBAE6cOIGTJ0/i48ePaNu2Lbp37w6AfYkzi7dN1Sz1hSQsLAxJSUkwNTWFiYkJAKB27dqoXbs2EhIS8OzZMxw6dAjv3r3D27dv8eTJEzg5OfGD/hXpXQRMTU1Rv3598XViYiKWLl2Kw4cPY9KkSXj8+DHu3r2Ls2fPpnkoMoObstS39SZMmID79+8jKCgI5ubm6NatG1xcXNC8eXMAwJIlS+Dq6oqtW7cqBThOFqss9fUAAGJjY/H27VsYGxtDR0cHr1+/Rrdu3dC0aVNMnjwZ+fLlw4ULF1C/fn1UrVpVjSXXDKnr988//4RcLkfz5s1ha2uLJUuWYPjw4di5cycEQUDfvn2hr6+PgIAA6OnpYcmSJbCxsWFwy4Cfnx+8vb3FKT6ePn2KzZs3o1KlSvD19UVCQgJ+++03VK1aFS1atECzZs0QExMjXgf4BTnzGN7UKPUvvxkzZuD69esIDAxE4cKFMWjQINSqVUvss1K8eHFoaWkhISEBtra2sLW1RbNmzdRZ/DwtdXC7dOkSLl++jLdv36J69eqoV68eypQpAwDQ0dFB1apVsXPnTtSpU0ccVZYyko++LuUiO2bMGFy7dg1Dhw6FQqFAcHAwpk+fDn9/f4waNUoMcCtWrEDbtm1x5MgR8XPNLx7/EQRB6ckJ/fr1g4GBAaRSKXR1dcXbT3Xq1MG0adOQL18+XLp0CatWrUKRIkXEzzSl78v6ffDgAXr27AlTU1NxnaVLl2LEiBHYs2cPnj17hjp16uD69et4/vw5ypQpwz6E35CUlISiRYuiQ4cO8Pf3R79+/dCkSRPMnj0b27Ztw/Tp05EvXz4kJSWhZs2akEqlYnDj4ISsYU2pUcoHddSoUThz5gxatmyJAQMGoFChQhg9ejQ2bdqEoKAgAJ8fIxIfH4+7d++qscSaIyUU7Nu3D0OHDsWNGzcQFBSEhQsXwsvLCwcPHhTXNTY2RmxsLN69eycuSwlu7FWQsQcPHuDBgwf4448/0K5dO3Tt2lX8UhEbGyuO5mvWrBn69++PIkWKIDo6Ws2lznvkcrn4mV25ciWuXLmC8PBwlC5dGvXq1cPQoUPh6OgoPqvU0NAQYWFhOHr0KAwMDFCwYEE1n0Hel1K/s2bNwoMHD7Bo0SJ06dIFFhYWEARBfATTkiVL0LJlS7x8+RKLFi3CixcvsHjxYnFwE32dra0thg4dikKFCmHt2rUoUaIEhg0bBgDo2LEjrKyscO3aNaxYsQLBwcFK2/KLXNaw5U0NUrcK3b59Gzdv3sT48ePFFgo3NzfMnTsX69evR5EiRdCtWzfo6OhAR0cHgYGB6iy6Rnn27BkWLFiAwYMHw9nZGcbGxnjy5AnGjh0rPt/R0dERFSpUQKFChfDgwQOULVtWaR+8oGQsKioKHz58QKFChaCtrY03b97AxcUFrVq1wrhx46Crq4tHjx6hfPnyaNu2LZo0acIWzXSktAg9fPgQfn5+8PT0hIODAwCgZ8+eiIiIwK1bt9ChQwdoaWnhyZMn2LhxI/755x9s3bpV7GZBGYuJicGjR4/Qtm1bsfO8v78/tm3bhoiICNjZ2aF79+4YM2YMevfujejoaJiamrLF7Qupbz8nJiZCEATo6uoCAEqUKIHExEQ8f/4cVlZW4kjTkJAQWFhYoEWLFihWrBjD8HdieMslqQNbyt8KhQJxcXEICgoSR4YlJSWJ8+IEBQVhxYoVaNGiBUxMTNCsWTPUrFlTbeegKVLqOjg4GIIgoGHDhjA2NoZCoRD7tvTu3Rt79uyBo6OjuA3nGMtYev1RkpKSIJFIYGFhgeDgYHTp0kXptt6JEyewa9cuzJo1C7/88guDWwYWLlyIdevWwdLSEi4uLuLn0d7eHv369YNMJkPfvn1RpEgR6OrqIjk5GZs2beLt0ixITk7Gq1evYGtri6dPn+LatWtYvHgxLCwsoK2tjf3790NPTw8dOnSAhYUFR0F/wd/fH8WKFRN/hx0/fhz79u1DWFgYWrRogY4dO6JAgQLQ0dGBpaUlfH19xZb227dvIyYmBm5ubkq3SvkFWTW8bZoLBEHA6dOnsWbNGnHZ2LFjsXHjRujq6sLAwAA3btyAIAjQ1tZGYmIiAKBr166IiIjAw4cPAXx+RuSXLUP0n5T5xFL+TkhIQHh4uNJEmklJSShZsiQmTJiA8+fP4969e9DX18f27dvRunVrtZRbE6SeLPbixYvipMYNGjRA8eLF0a9fP7Rq1QoNGzbEjBkzYGBggJCQEJw/fx758+dnaMuEwYMHo3z58vD394ePj4/SpLENGjTA2rVrsXTpUri5uWHs2LF8/us3pDfhubGxMYYNG4atW7eiV69eWLduHfr06YNDhw5h1apVKFeuHB4/fqyG0uZ927ZtQ9euXXHjxg1IpVKcPHkSXl5ekMlkKFCgAJYuXYqpU6eKE2/36NEDRkZGsLe3h6urKyZMmIDmzZsrDVJicFMdW95yQVJSEt6+fYtNmzYhJCQEAQEBuHfvHvr374/ChQujYMGC2LNnDypUqABra2vxG3d8fDwMDAzEoewpzdL0n3///RdXrlyBm5sbtLW1sWfPHly9ehWzZs1C8eLFUbhwYWzfvh3Dhw+Hubm5eLHQ1dUV/wBAsWLFAHC0U3pSD6wZNWoU/Pz80LhxY1hZWcHExASDBg3CihUrIJfLMWLECOjr6+PVq1dYs2YNLl68iC1btnBU6Re+HFUKfJ5hftu2bejWrRv279+PypUro0mTJtDS0hI726cMqKGMpa5fX19fREVFoVq1ajAxMYGzszNsbW0RGRkJMzMzVKhQAQCQL18+aGtrs//gV5iamqJYsWKYNm0aJk+ejNDQUAwaNAgDBgyAtrY2Lly4gKFDhyIhIQFeXl6oWrUqli1bhsOHDyMhIQFubm7i1EtsccsGOfngVPpPRESEMGfOHKFSpUpCjRo1hMePH4vv/fvvv0L16tWFnj17CmfOnBEEQRDevHkjeHl5CS1bthRCQkLUVew8TS6XC//884/g4OAguLu7C3v27BFsbGwEb29vcZ0FCxYIFSpUEJYvXy74+/sLgiAI8fHxwtatWwVHR0fhxYsX6iq+xhk3bpzQqFEj4fz580J4eLi4PC4uTti3b5/QrFkzoVatWkLbtm2FDh06CI0aNRIePXqkvgLnUfHx8eK/b9y4IVy8eFGIiooSl8XExAhOTk5Cw4YNhRMnTghJSUmCIPDh3KoYPny4ULNmTcHGxkaoV6+e8NdffwmhoaGCIAjiQ9EFQRACAgKECRMmCPXq1RPevHmjruLmeadPnxacnZ0FJycnoVmzZsL+/fsFQfivLq9cuSLY2dkJbm5ugp+fn7hdcnKy+G9+jrMHJ+nNRXPnzsXff/8NbW1tODk54Y8//hDfu3v3rvitRSKRoECBAggPD8fGjRt5ayQD0dHR8PHxwbRp05CUlIRx48bBxcVFaSLYyZMn49ChQyhZsiTs7e0RGRmJY8eOYciQIXBzc1PzGWiGp0+fYvDgwRg6dCjatWsntk6mtFTK5XJER0fjwIEDiImJgZWVFapXry52Vv7ZxcXFYe3atRgyZIjSKPPz588jNjYWBQsWhJeXF+rWrQsTExPExsaic+fOiIuLw/jx49GwYUOlx+JR+lL6DAPAnj17sH79eowePRolS5bEihUrcPfuXfFpKilThKxZswaXLl3CmzdvxFunpExI1VLm4+ODLVu24O7du5g+fTrat28v3qKWyWS4evWqOJfb6NGjWZ85hOEtF7179w5BQUE4duwYTp06hcaNG2PSpEni+8HBwbhw4QI+fPggTiabcjuP0kq5oFy6dAm//fYbgM8Pml+7di2Az7ed9fT0AHzur3H16lU8ePAANjY2aNiwIWf0zoILFy5g4MCBOHXqFKysrMTQxrrLnC1btmD+/Plo06YNZs2ahSNHjmD58uX4/fffoaenh3379uHMmTMYM2YMnJycYGZmhtjYWDg7OyMgIAALFy4UB9eQspiYGNy/f18cnQsABw8eRGJionhrL8XkyZNx8eJFMcAZGBhg165dePHiBfr27YsSJUqo4Qw0Q+r/62fOnMGyZcsQHByMpUuXwt7eHoIgiF0srly5gr59+2LlypX83OYQhjc1CAsLw8qVK+Hj4wNHR0dMnjxZfO/s2bP49ddfOfIxCx4/fozAwEC8ffsWK1euRMWKFbFu3ToAnwctpO4r+OnTJ+jr64v1yz5uaaVXJ//++y+6du2KBQsWoGXLlmnWO3r0KMzMzMRfoAx1ysLCwrB582YcOnQItWvXFkOCu7u7uM6ECRNw8OBBjBs3TgxwMTEx6Nu3L+bNm8dgkQ5BEDBy5EhIJBLMmzcPWlpauHbtGnr37g0A8PT0hLu7u1KLXEqAc3JywsCBA2FsbJzmOkHpS/3/+uzZs1i9ejWio6MxZcqUNAHu48ePKFy4sJpL/APL/Tu1JAiCEBwcLEyfPl2oX7++MHHiROHNmzfCH3/8ITRu3FgIDAxUd/E0UkxMjODt7S3UqlVL6N+/v7hcLpcLd+/eFfu6pEjd54U+S9035caNG+Jrf39/wcnJSXB3dxeePn0qrqNQKIR3794JQ4cOFTZv3qy0/c/uy89XfHy8MH36dKFdu3ZCtWrVhL179wqCIAgJCQniOuPHjxcqVKggbNu2Tezrys9pxj5+/CjExMQIgiAIz58/FwRBEHbu3CnUrVtX6Nmzp1i/iYmJ4jZTp04VqlSpIixevJh9sLIo9efRx8dH7AN348aNNO8LAvu45RQ2OahJwYIFMXjwYLRs2RInTpxA9+7d8c8//2Dp0qV8qLQKBEGAvr4+2rdvjyFDhuDff/+Fm5sbAgMDcezYMQwYMAA3btxQ2oYtQ8pSj9CbMGECZs2ahU2bNgEALC0t4eHhgfPnz2PFihW4dOkSAODJkyf466+/cPv2bTRo0CDNCMqflZDO9EDz589Hvnz54ODgAEEQcODAAQCfH9GWMj3QzJkz0bFjR0ybNg1nz56FQqFQR/E1ioWFBfT19bF27Vp06dIFly9fhrOzM4YMGYK7d+9i3LhxAABtbW1x2qBJkybB2dkZHTp0YMt7FkkkEvHJM02aNMGAAQNgYmKCcePG4cqVK2muq6zfnMHbpmoWFRWFp0+fIiAgAPb29ihatKi6i6SxhP836cfExODAgQNYvny5uLxnz54YMmSImkuoGTw9PXHv3j2MHz8e5cqVU/pMHjhwAAsXLkRkZCT09fWRL18+yOVydvT+QmJiIry9vbF+/Xq0bt0a/v7+uHv3Lnbt2gUzMzOsXbsWu3fvRoMGDTB79mxIJBKlQTYzZsxA9+7dUbp0aTWfieZ4+fIlJk+ejKCgIEyePBl16tTBzp07MXPmTDRr1gwLFy4EAKV6JmXCF90d0pvSJr11fXx8xDkI27Vrlytl/dkxvNEPJeWCkpCQgKdPn+Lff/9F0aJF0aBBAwDs4/Ytf//9N1asWIFFixbBzs4OMpkMsbGxCAoKgrGxMUxNTfH06VO8ePECT58+RdmyZVGtWjV+6UhHZGQk/vrrL2zbtg26urrw9vYWR45HRkZizZo1OHr0KGrVqoU5c+YAYLD4Xm/fvsWECRPw8eNHTJ06VSnAOTk5Yd68eeouokZIeaTdt6QOcClPX6Dcwd9i9ENJPQmvnZ0devToweCWBZGRkTAwMEDx4sUhk8lw8+ZNuLq6om/fvmjVqhXOnDkDGxsbtGrVCiNHjkSbNm0Y3L4i9eTaKRNIp35v4MCBaNWqFa5du4YJEyYAAIPbd7KyssLMmTNRuHBhTJ48GZcvX0a3bt3wxx9/4NChQ0rTM1H6njx5goEDB+Kff/755roSiUS8tZ8S3NgelDv4hAXKs75swv9eDG7KUtdvyr+lUik+fvyIlStXIjw8HD4+PqhXrx66du2Ks2fPYubMmahTpw7y5cun5tJrBldXVzRr1kycHkgQBHF6oJQAJ5VKsWvXLshkMkybNk3NJdZ8KQFuwoQJmDx5MqZNm4auXbtCJpOhSpUq6i5enmdoaAhBEMR+rN/y5ZRB7EucOxjeKE9KfTG4d+8e3r9/j7CwMDRq1AgFChTI1LD+7A5/P5Lk5GRoaf333z+lnvr06YMXL17g2rVr+OWXXzBx4kR07dpVXCcgIADx8fEMb5lUtGhRFC1aFMWLF4cgCPDx8QEApQBXokQJdOzYET169FBnUX8oKQFu0qRJGD58OJYvX45OnTqpu1h5nkKhgKWlJQYOHIiVK1eiRYsW3+zLmvo6u2fPHpQqVQrVq1fPjeL+1BjeKE9KuRj8/fffmD9/PgwMDBATE4MVK1agT58+cHJyyrB/ReoLyoULF2BlZfXTz5OV0vlYEAQxuK1atQpPnz6FsbExypYtCxcXF8yYMQMxMTEQBEF8oPynT59w/fp1FC5cmPNhqcDMzEycLNbHxwdJSUlwc3PD6tWr8fDhQ6xatYpzYmUzKysrTJ48GXPnzmXdfkPqefAAoGrVqjAxMcHNmzdRrly5rw5cSH2d3bp1K2bMmIH58+czvOWGXJmQhEgFV69eFapXry5s2rRJfAbp/PnzhfLlywsrVqxQmrcptdTzDG3atEmwsbERLl++nCtlzqsSEhKEzp07C7t27RKXeXp6CjVr1hRcXV2FDh06CBUqVBB+++23NPMM3rx5U/Dy8hJq1qypNMcbZV1ISIgwZ84coUaNGkKdOnWE+vXrCw8ePFB3sX5oX7tO/MxSXyOPHz8uzJ49W7h//77SOl5eXkLDhg2V5iH82j42b94s2NraCnv27MmZAlMabHmjPOvRo0coU6YMWrRoAQsLCwDAmzdvUKRIETRp0gTa2tppvhEKqb4Jent7Y/78+Zg2bZrSo3N+RnFxcTA3N8fs2bOhq6uLsmXL4vXr11iyZAkcHBwQHR2NK1euYNKkSZg0aRJWrVoFANi9ezdWrlwJMzMzbNmyBdbW1mo+E81WoEAB/Pbbb2jcuDGnB8olfCbsf1KeJJFyjUxOTsazZ8/wzz//YOvWrejYsSPs7e3Rpk0b9O/fHw8ePMD27dvRu3dvpS4oX15nZ8+ejWnTpqFz585qOa+fkrrTI5EgKH+LCw4OFgRBECZMmCA0b95cXN6/f3+hQYMGwuPHjwVB+PwEgKtXr4rbpt7Hli1bBFtbW2H37t25UXyNEBoaKnh5eQmVK1cWZs6cKbi5uQmxsbFK61y4cEGoVKmSsHz5cnHZqVOnhI8fP+Z2cYkoGz1+/FiYO3eu+BSKzZs3C61btxYE4fO14cCBA4Kzs7NQt25doVevXsKOHTuEli1bCr///vtX97lp0yahXLlyvM6qAVveKE9I+Ra3a9cuXLhwAV5eXrCxscG1a9fw5MkTLFy4EM+fP8eqVatga2uLyMhI7Ny5E8WKFUPVqlWho6Mj7mPLli2YO3cupk2bhi5duqjztPIE4f/fks3MzDBq1ChIpVJs2bIFlpaWCA8PVxp8ULNmTTRp0gTXr19HdHQ0DA0N0bRpUzWWnoi+h/D/qTv09fVx8eJF/PPPP2jZsiX++usvDBkyBIIgwMzMDO3atUPdunUREBCApUuX4siRI/Dz84Ofnx8aN26M5s2bK+332LFjmD9/PqZMmcLrrBpw7gRSKyHVnECBgYFYtWoVKlWqBEtLS9SrVw9hYWHo3r07Xrx4gTVr1qBcuXJITEzEmTNncPv2bZQvX15pbqyDBw9i1qxZvKD8n1wuV7rdUbBgQXh5ecHFxQUBAQE4deqU+Mgg4POcZGZmZggMDORIXaIfQHBwMCQSCSwtLbF27VqEh4fjr7/+Qv/+/eHu7p7m+lClShVs3LgRY8aMwejRo2FmZobz589DoVAoPa7NwsICS5YsEUejU+5iyxupVcqF49KlS3jx4gXKlSuHDh06QCKRoESJEli2bBmGDBkCCwsLvH//HrGxsbh69SrWrFmDwYMHi61CKa1L0dHRWLp0aZpviT+j1P0Bjx07hqCgICQmJqJNmzZwc3ODIAhYsGAB9PT00KxZM5iZmSEoKEjsV8jwRqTZVqxYgUOHDmH//v3Q19dHVFQUYmJiYGBggDNnzqBt27ZpHsGWMpm5nZ0d7OzsYGRkhClTpmDw4MGwsrIS1+OIUvXi47FI7QIDAzF48GD4+/ujdOnS2LlzJ4D/5iK7efMmJk+ejLi4OERERKBUqVJo06YNevXqBYBPTkiPkKpD8fDhw3Hv3j0kJCRALpdDKpVi8ODBcHBwwM6dO7F9+3bY29vDysoK4eHhuHv3LjZs2CA+yomINNOlS5dgZGQEOzs7MbQ9evQIycnJ8PLygkwmw6JFi1C2bNk026Y8qi0wMBCdO3fG77//jrZt26rhLCg9DG+UJxw9ehRbt27FnTt3sG7dOvz6668QBAEKhQIymQyfPn1CdHQ04uPjYWJigoIFCwJgcPuWxYsXY+/evVi0aBEsLS0hk8kwb948nD59Gh4eHnBycsLGjRuxfft2VKhQAf369UOlSpWUvmETkWYRvpig3NfXF56enti+fTvKlCmD5ORkPHnyBGPGjIFUKsWSJUtQpkwZAMA///yDSpUqwczMDADw77//okuXLli0aBGcnJzUcj6UFn/rUa762neFVq1aoV+/frC1tcWUKVNw8+ZNSCQSSCQSyOVymJiYwNLSEmXKlBGDmyAIDG4ZSExMxJMnT9CgQQPUrFkTRYoUgYWFBRYuXIiWLVti1apViImJwciRI9GqVSsEBgaicePGDG5EGk4ikSj1ZdXS0oKZmRnc3Nzg5+cHLS0t2NraYt68eVAoFBg5ciROnTqFv//+G+7u7jh69CiAz1OLnD9/HvXr12dwy2PY8ka5JvW3wbt378LPzw8SiQRFihRB7dq1AQAnT57Ehg0bEB0djalTp6JGjRp8zJWKEhMT4ezsjGLFimHZsmUA/ptJPSkpCa1atUKNGjUwa9YshIaGIjk5WZxPj4g0z/379+Hn54cOHToAAPbu3Yu3b9/C09MTFy5cwJIlSxAcHIxNmzahdOnSSE5OxtOnTzF+/Hi8evUKhoaG6NOnDwYOHCjuMzAwULwu8E5H3sEBC5RrUgLYvn37MHPmTBQuXBghISHQ1dVFvXr1MHPmTDRv3hxSqRTr1q3DtGnT8Mcff8De3l7NJddMUqkUtra2uHnzJu7fvw87OztxwlKpVAozMzNERUUB+Dx5LBFpruTkZAQEBGDatGni4K8JEybgjz/+AADUr18fgiBg6dKl6NOnjxjgKlSogL///huXL1+Gqakp7OzsxP1paWmJwY13OvIW/iQoV928eRNz587F4MGDsWHDBpw+fRrDhw/H3r178eeffwIAmjZtigEDBkBLSwujRo1CUFDQV2+30tdpaWmhT58+CAoKwurVq/Hs2TPxvYiICEilUvzyyy8QBIH1S6ThtLS0UL16dbi7u2Pz5s3w8vLCjBkz4OLiguTkZABAgwYNMHz4cBQqVAh9+vSBn58fgM9PoWjQoIEY3BQKhfj84xS8+5G3sOWNctX9+/dRtGhRtG7dWvxGd/z4cVhZWaFhw4biek2bNkVCQgKkUinMzc3VVFrNZ2Njg6VLl2LYsGH48OEDHB0dYWFhgYsXL+LFixeYMWMGL8pEPwgLCwsUL14cycnJkEqlePz4MYDPwS5l9GiDBg0AfJ5GxMXFBd7e3mlGm7KFLe9jeKMck15ftbdv3wIAChcuDABwc3PD8+fPsXr1atja2sLX1xdBQUHo0KEDWrduneG+KHMaNmyIrVu3Yu7cudixYwd0dHRgYWGBLVu2oFSpUuouHhFlg5R5HY2MjDBnzhz4+flh8+bNkEgkmDhxInR0dJQCnFQqxeTJk3H37t10pwqhvI3hjXJMSti6cuUKqlevDh0dHdjY2GDv3r148+YNFi5ciGfPnonB7dOnT7hw4QKkUqn4aKYv90WqsbOzw5o1axAdHQ2FQoH8+fMr1S8RaZ7UX2oTEhKgr6+PunXrAgA+fvwIqVSKjRs3AoAY4BQKBV69eoV69eph586dvLOhoRjeKEe9f/8eo0ePhrOzM4YNG4Z69eqhXLlyaNeuHfT19bF//35YWFggKSkJZ86cwalTpzB27FgGixxgYGAAAwMDdReDiLJJSnA7ffo09u7dC4lEgho1asDZ2RmFCxeGs7MzAGDjxo2QSqUYNWoUzpw5g2nTpmHx4sVwcHAAwDsbmojhjXKUqakpbG1tcevWLSgUClhaWqJbt27YunUrwsPD8fbtWzx79gyPHz/GypUr8dtvv6FFixbqLjYRkUbw8fGBp6cn6tWrB39/fzx58gRXr17FwoULUaRIETg7O0MikWDNmjU4d+4cwsPD0adPHzG4AbyzoYk4zxvlmJSh5o8ePUK3bt3w+++/o2fPngA+f1M8cOAAfH19oaenh+LFi6NVq1bi+5xPiIgoY1FRUVi0aBEKFCiAgQMHQkdHBxs3bhRvh65cuRL58+dHaGgo/v33X9y7dw+2trZo1qwZAF5nNRnDG2W7lGfoAZ8vDrGxsZg2bRo+fPiA+fPni4MVAODFixfQ19eHlpaW2PeCFxQiooz5+PjA29sbANC3b180atQIwOfJuffs2YMtW7bAwsICK1asQP78+dNsz+usZuNPjrLVqVOn8Pvvv+PEiRMAPg85NzQ0RKNGjXDnzh08ffoUwOcLBwCUKVMGRYoUQaFChQBwIkgioswwMTHBw4cPcf36dQQHB4vLdXR00LVrV/Tq1QshISFwd3cXJ+NOjddZzcafHmWrjx8/IiwsDKNHj8Zvv/2Gffv2AQCcnJzQrFkzLFy4EJ8+fUpz4Ujpc8G+F0RE6Ut9o8ze3h4bN25EwYIFsXv3bvGLMfB50t2uXbuie/fuePXqFa5cuaKO4lIO4m1TUtnXRih9+vQJ9+7dw7JlyxASEgIzMzMMHToUb968wcmTJ9GvXz+xzwUREX1d6utsXFwcpFIpdHV1xfdv3bqFwYMHo3z58hg/fjysra3F95KSkvDy5UvY2NjkerkpZzG8kUpSX1AePHiAkJAQhIaGwtHREYaGhtDR0UF4eDju37+PDRs2wN/fHwULFsT9+/fRpEkT8VFYRESUvtTX2WPHjmHXrl0ICQlB/vz50bdvX9SoUQMFChTAzZs34eHhIT7PNL1Jd9nH7cfC8EbfZe/evZg/fz50dHQQExMjXlSaN2+uNDBh//79ePDgAbZv346hQ4fCw8NDjaUmItIchw8fxrhx49CpUyeYm5vj6dOnuHfvHurUqYMRI0bAwsICt2/fxpAhQ1CqVClMnDgRtra26i425SCGN1LZlStX4OHhgeHDh6N27dqwsbHBpEmTcODAAQwbNgx9+vSBRCKBTCYTt3n37h2KFi0KgBNDEhGlJ3UrWVhYGNzc3FCrVi0MGTIE+vr6AIDatWvD2toa8+bNE78o37x5E66urli+fDmaNm2qtvJTzmMbKqns/v37qFChApycnMQ+FSEhIShcuDAaNGgALS2tNOGsSJEiAD5fnBjciIj+c/78eYSFhUEqlYoj8mNiYhAQEIBq1aqJwW3w4MHQ0dHBuHHjULhwYQQGBiI+Ph41atTAhQsXGNx+AgxvlCnpNdA+fPgQ0dHR4vxsAwYMwMOHD7Fs2TKULVsWt2/fxr1795S2SQls7HtBRPQfHx8fjBgxAqtXr0Z4eLh4jdTR0YFMJhOn+xg4cCAeP36MNWvWoFy5cnjw4AH+/PNPcbqQ1PNl0o+Lv0Hpm1Lf3nzx4gWeP38OAKhYsSISExPx8uVLuLm54fnz51i1apX4kHlvb29cv34dycnJ6iw+EVGe17RpU7Rt2xZnzpzB6tWrERYWBgDQ09NDkSJFcOTIEfTq1QtPnz7FmjVrYGtri+TkZNy+fRvPnj1DQkKC0v74BfnHxp8uZSh1cDt06BBGjhwJb29vREREoHbt2vD390e3bt3g5+eHdevWoVy5ckhKSsK5c+dw//59lC5dGlpafIQuEdHXJCYmAgCmTZuG+vXr49y5c2KAMzY2xpgxY3Dz5k1cv34d48aNg7W1NaKionD48GEsX74cbdu2RZkyZdR8FpSbOGCBMuXQoUP4448/4O7uDkdHR3Ek04kTJzBy5EjUqFEDgwcPhpGREXx9ffHXX39h8ODBGDhwoJpLTkSUd6X+gvzkyRO8fv0aM2bMgCAIaNu2Ldzc3GBmZobz589j+PDhKFu2LIyNjaGlpYV79+6hT58+GDRoUJp90Y+N4Y2+yd/fHwMGDEDbtm0xcOBAaGtri8t1dHTw4cMH/P7770hISEBcXByKFSuGtm3bok+fPgA4vxARUWopISt12Dpw4ACmTJmCNm3aIDY2Fq9fv8aLFy/Qo0cPMcA9evQIZ8+exePHj1GxYkWULVsWTZo0AcDr7M+G97Pom+Lj4xEbGws7Oztoa2sjLCwM06dPx4MHDxAQEICRI0di9+7dCA8PR0JCAkxNTcWh67ygEBEpe/r0KWxtbcXg9uHDByxatAguLi4YNmyY+AQFLy8vHD58GADg5uaG8uXLo1y5cmla13id/fkwvNE3GRkZITo6Grt27cKJEydw/fp1SCQS9OjRA7GxsVi0aBFKly6Nxo0bK23Hh8wTESlbt24dDh06hM2bN8PExAQSiQQxMTGIjIxE1apVoauri6SkJGhra2POnDn47bffsHnzZkilUvTv3x9mZmZp9snr7M+HP3H6JgsLC6xcuRJPnjzBx48f0aBBA/EZpU5OTihSpEi6Fw/2vSAiUta8eXPMnj0bpqamCAkJAfD5GiuVSvHw4UMAnx8snzKIYdKkSTAxMcHJkyexZMmSNKNK6efEljfKFAcHBxw8eBA6Ojpin7f4+Hg8ePAAAGBqaqrO4hERaYRixYoBAK5fv47Ro0dj4sSJaNasGZo3bw4fHx9UqlQJjo6O0NHRAQDxWaaWlpZiyxwRwxtlmoGBgfjv+/fv499//8X8+fPx22+/oUqVKuorGBGRhjE3N0fhwoWxePFimJmZYejQoejfvz/WrVuHqKgotGvXDlFRUXj+/DlKly6NuXPnIn/+/OouNuURHG1KWebv74+xY8ciNDQU3bt3F0eVcpg6EVHm+fv7Y/z48fjw4QMWL16MfPnyYdKkSXj69CmKFi0KfX19/Pvvvxg6dCjc3d0B8DpLnzG8UZbJ5XI8fPgQSUlJqF69OgCOdiIiUsXbt28xfvx4fPz4EQsXLkTJkiVx9uxZnDhxAoUKFULVqlXRsWNHAAxu9B+GN/puvKAQEakudYCbNm0a6tSpk+a6yi/IlBo/CfTdGNyIiFRnZWWFWbNmwdLSEuPHj8epU6fSXFcZ3Cg1fhqIiIjUzMrKClOnToWZmRliYmLUXRzK43jblIiIKI+IioriqFL6JoY3IiKiPIZ9iSkjvG1KRESUxzC4UUYY3oiIiIg0CMMbERERkQZheCMiIiLSIAxvRERERBqE4Y2IiIhIgzC8EREREWkQhjci0hiOjo7w8vJS2/G9vLzg6OiotCwmJgYTJkxA3bp1YWNjg5kzZyIgIAA2NjbYt29frpexZ8+e6NmzZ64fl4hyj5a6C0BEBHx+OPe6devg6+uLoKAgaGtrw9raGk5OTnB2doaenp66i5iu1atXY//+/fjtt99QrFgxlC5dOseP+eLFCxw/fhwdOnSApaVljh+PiPIWhjciUrvz589j+PDh0NHRQbt27WBtbY2kpCTcunUL8+fPx4sXLzB9+nR1FxPTp0/Hlw+luXr1KipXrowhQ4aIywRBwP3796GllTOX2BcvXuDPP/9EzZo104S39evX58gxiSjvYHgjIrXy9/eHp6cnihQpgs2bN8Pc3Fx8z8XFBW/evMH58+fVV8BUtLW10ywLDQ1FmTJllJZJJBLo6urmVrGU6OjoqOW4RJR72OeNiNRq3bp1iI2NxcyZM5WCW4rixYujd+/e6W776dMnzJ07F23atEHVqlVRrVo1DBgwAE+ePEmzrre3N1q1aoXKlSvD3t4eHTt2xOHDh8X3o6OjMXPmTDg6OqJixYpwcHBA37598fDhQ3Gd1H3erl27BhsbGwQEBOD8+fOwsbERX3+tz5ufnx+GDx+O2rVrw87ODs2bN8fixYvF99+9e4cpU6agefPmsLOzQ61atTBs2DAEBASI6+zbtw/Dhw8HAPTq1Us87rVr1wCk3+ctNDQU48ePR506dVCpUiW0bdsW+/fvV1onpczr16/Hrl270KRJE1SsWBGdOnXC/fv3061/IlIPtrwRkVqdO3cOxYoVQ7Vq1bK8rb+/P06fPo0WLVrA0tISISEh2LVrF1xdXXH06FFYWFgAAHbv3o0ZM2agefPm6NWrFxISEvD06VPcu3cPbdq0AQBMnjwZJ0+ehKurK0qXLo1Pnz7h1q1b8PPzQ4UKFdIcu3Tp0pg3bx5mz56NwoULo2/fvgAAMzMzhIWFpVn/yZMncHFxgZaWFpydnVG0aFG8ffsWZ8+ehaenJwDgwYMHuHPnDlq1aoXChQvj3bt32LFjB3r16oWjR48iX758sLe3R8+ePeHt7Y1BgwahVKlSYnnSEx8fj549e+Lt27dwcXGBpaUlTpw4AS8vL0RGRqYJxkeOHEFMTAycnZ0hkUiwbt06DB06FKdPn0635ZGI1EAgIlKTqKgowdraWhg8eHCm1m/UqJEwduxY8XVCQoIgl8uV1vH39xcqVqwo/Pnnn+KywYMHC61atcpw39WrVxemTp2a4Tpjx44VGjVqlKZMAwcOTFMGa2trYe/eveIyFxcXoWrVqsK7d++U1lUoFOK/4+Li0hzzzp07grW1tbB//35x2fHjxwVra2vh6tWradZ3dXUVXF1dxdebNm0SrK2thYMHD4rLEhMTBWdnZ6FKlSpCVFSUUplr1qwpfPr0SVz39OnTgrW1tXD27Nl064SIch9vmxKR2kRHRwMADAwMVNpeR0cHUunny5hcLkd4eDj09fVRsmRJPHr0SFzPyMgIHz9+zPD2n5GREe7du4fAwECVypKRsLAw3LhxA506dUKRIkWU3pNIJOK/U4+oTUpKQnh4OKysrGBkZKR0Pllx4cIFFCpUCK1btxaXaWtro2fPnoiNjcWNGzeU1m/ZsiWMjY3F1zVq1ADwuZWTiPIG3jYlIrUxNDQE8HmuNFUoFAps2bIF27dvR0BAAORyufieiYmJ+G83NzdcvnwZXbp0QfHixVG3bl20bt0a1atXF9cZPXo0vLy80LBhQ1SoUAENGjRA+/btUaxYMdVOLpWU4GNtbZ3hevHx8Vi9ejX27duHwMBApZGtUVFRKh373bt3KF68uBhyU6TcZn3//r3S8l9++UXpdUqQi4yMVOn4RJT9GN6ISG0MDQ1hbm6O58+fq7T9qlWrsHTpUnTq1AnDhw+HsbExpFIpZs2apRR8SpcujRMnTuD8+fO4ePEiTp06he3bt8PDwwPDhg0D8LnFqUaNGvDx8YGvry/Wr1+PtWvXYvny5WjQoEG2nO+3TJ8+Hfv27UPv3r1RpUoV5M+fHxKJBJ6enmmmKMkpMpks3eW5dXwi+jaGNyJSq0aNGmHXrl24c+cOqlatmqVtT548iVq1amHWrFlKyyMjI2Fqaqq0TF9fHy1btkTLli2RmJiIoUOHYtWqVXB3dxen9TA3N4eLiwtcXFwQGhqKDh06YNWqVd8d3lJa7549e/bN82nfvr3SUyQSEhLStLqlvtX6LUWLFsXTp0+hUCiUWt9evnwJAGlu4xJR3sc+b0SkVgMGDIC+vj4mTpyIkJCQNO+/ffsWmzdvTndbmUyWpkXo+PHjafqthYeHK73W0dFB6dKlIQgCkpKSIJfL0wSkAgUKwNzcHImJiaqclhIzMzPY29tj7969aW5Tpi5/eq1e3t7eSreDASBfvnwAMncrtX79+ggODsaxY8fEZcnJyfD29oa+vj7s7e2zdC5EpH5seSMitbKyssKCBQvg6emJli1bik9YSExMxJ07d3DixAl07Ngx3W0bNmyIFStWYNy4cahatSqePXuGw4cPp+mn1r9/fxQsWBDVqlVDgQIF8PLlS2zduhUNGjSAoaEhIiMj0aBBAzRv3hy2trbQ19fH5cuX8eDBg2x7lurEiRPRvXt3dOjQAc7OzrC0tMS7d+9w/vx5HDx4UDyfgwcPwtDQEGXKlMHdu3dx+fJlpf57AFCuXDnIZDKsXbsWUVFR0NHRQe3atVGgQIE0x3V2dsauXbvg5eWFhw8fomjRojh58iRu376N8ePHi/0OiUhzMLwRkdo1btwYhw4dwvr163HmzBns2LEDOjo6sLGxgZeXF7p27ZrudoMGDUJcXBwOHz6MY8eOoXz58li9ejUWLlyotJ6zszMOHz6MjRs3IjY2FoULF0bPnj3x22+/Afg8yrN79+7w9fXFqVOnIAgCrKysMHnyZPTo0SNbztHW1ha7d+/G0qVLsWPHDiQkJKBIkSJwcnIS15kwYQKkUikOHz6MhIQEVKtWDRs3bsSAAQOU9lWoUCFMnToVq1evxoQJEyCXy7Fly5Z0w5uenh68vb2xYMEC7N+/H9HR0ShZsiRmz5791VBMRHmbRGAvVCIiIiKNwT5vRERERBqE4Y2IiIhIgzC8EREREWkQhjciIiIiDcLwRkRERKRBGN6IiIiINAjDGxEREZEGYXgjIiIi0iAMb0REREQahOGNiIiISIMwvBERERFpEIY3IiIiIg3yP/8JEhbs+bBAAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_differences(\"F1 Score differences\", f1_scores, f1_scores_tuned)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "environment": {
+   "kernel": "conda-base-py",
+   "name": "workbench-notebooks.m126",
+   "type": "gcloud",
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m126"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel) (Local)",
+   "language": "python",
+   "name": "conda-base-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/public_datasets/public_datasets.ipynb
+++ b/public_datasets/public_datasets.ipynb
@@ -325,7 +325,6 @@
    "cell_type": "markdown",
    "id": "82809505",
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -356,19 +355,60 @@
     "| 3        | -1.108463 | 53.902506| 74126         | 10/1988-T3         | Ash                   | Fraxinus Excelsior    | Ash     | Private        | Darling Lane/Mill Lane, Acaster Malbis                         | Single tree | 0   | 0.0    | 0.0    | 0     | 0       |0       |\n",
     "| 4        | -1.134858 | 53.999193| 74127         | 1973/107-T9        | Sycamore              | Acer Pseudoplatanus   | Sycamore| Private       | The Vale, Skelton Village                          | Single tree | 0   | 0.0    | 0.0    | 0     | 0       |0       |"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d34d728-6bd2-414d-9c39-dad38541bd4c",
+   "metadata": {},
+   "source": [
+    "**[jigsaw_multilingual_toxic_comment_classification](https://www.kaggle.com/competitions/jigsaw-multilingual-toxic-comment-classification/data)**  \n",
+    "GCS bucket paths:  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/jigsaw-toxic-comment-train-processed-seqlen128.csv  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/jigsaw-toxic-comment-train.csv  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/jigsaw-unintended-bias-train-processed-seqlen128.csv  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/jigsaw-unintended-bias-train.csv  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/sample_submission.csv  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/test-processed-seqlen128.csv  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/test.csv  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/test_labels.csv  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/validation-processed-seqlen128.csv  \n",
+    "gs://dataproc-metastore-public-binaries/jigsaw/validation.csv  \n",
+    "\n",
+    "- Format: .csv\n",
+    "- Description: 223.549 Human text toxic comments classified into different Responsible AI harms categories: \"toxic\", \"severe_toxic\", \"obscene\", \"threat\", \"insult\", \"identity_hate\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "479e1d96-2a52-4cce-bdf8-df2d49efe4c4",
+   "metadata": {},
+   "source": [
+    "| index | id                                 | comment_text                                                             | toxic | severe_toxic | obscene | threat | insult | identity_hate |\n",
+    "|-------|------------------------------------|-------------------------------------------------------------------------|-------|--------------|---------|--------|--------|----------------|\n",
+    "| 0     | 0000997932d777bf                   | Explanation Why the edits made under my username...                      | 0     | 0            | 0       | 0      | 0      | 0              |\n",
+    "| 1     | 000103f0d9cfb60f                   | D'aww! He matches this background colour I'm so...                       | 0     | 0            | 0       | 0      | 0      | 0              |\n",
+    "| 2     | 000113f07ec002fd                   | Hey man, I'm really not trying to edit war. It...                         | 0     | 0            | 0       | 0      | 0      | 0              |\n",
+    "| 3     | 0001b41b1c6bb37e                   | \" More I can't make any real suggestions on im...                        | 0     | 0            | 0       | 0      | 0      | 0              |\n",
+    "| 4     | 0001d958c54c6e35                   | You, sir, are my hero. Any chance you remember...                        | 0     | 0            | 0       | 0      | 0      | 0              |\n",
+    "| 5     | 00025465d4725e87                   | \" Congratulations from me as well, use the to...                         | 0     | 0            | 0       | 0      | 0      | 0              |\n",
+    "| 6     | 0002bcb3da6cb337                   | COCKSUCKER BEFORE YOU PISS AROUND ON MY WORK                              | 1     | 1            | 1       | 0      | 1      | 0              |\n",
+    "| 7     | 00031b1e95af7921                   | Your vandalism to the Matt Shirvington article...                        | 0     | 0            | 0       | 0      | 0      | 0              |\n",
+    "| 8     | 00037261f536c51d                   | Sorry if the word 'nonsense' was offensive to...                         | 0     | 0            | 0       | 0      | 0      | 0              |\n",
+    "| 9     | 00040093b2687caa                   | alignment on this subject and which are contra...                        | 0     | 0            | 0       | 0      | 0      | 0              |\n"
+   ]
   }
  ],
  "metadata": {
   "environment": {
-   "kernel": "7a42ae6b283a613cfabce6f7-python3",
-   "name": "workbench-notebooks.m120",
+   "kernel": "conda-base-py",
+   "name": "workbench-notebooks.m126",
    "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m120"
+   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m126"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel) (Local)",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -380,7 +420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add notebook to classify human text toxic comments into different Responsible AI harms categories: "toxic", "severe_toxic", "obscene", "threat", "insult", "identity_hate" using BigQuery Dataframes, Gemini, and Vertex AI Supervised Fine Tuning.  
Closes #45 