### PR TITLE
fix: adjust vector search notebook for antigravity

### DIFF
--- a/notebooks/analytics/image_based_home_search.ipynb
+++ b/notebooks/analytics/image_based_home_search.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install bigquery-magics -q"
+    "!pip3 install google-cloud-bigquery google-cloud-bigquery-storage tqdm pandas db-dtypes jupyter ipywidgets -q"
    ]
   },
   {
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext bigquery_magics"
+    "%load_ext google.cloud.bigquery"
    ]
   },
   {
@@ -123,9 +123,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PROJECT_ID = \"PROJECT_ID\"\n",
-    "DATASET_ID = \"DATASET_ID\"\n",
+    "PROJECT_ID = \"\" # @param {type:\"string\"}\n",
+    "DATASET_ID = \"\" # @param {type:\"string\"}\n",
+    "\n",
+    "if not PROJECT_ID: \n",
+    "    PROJECT_ID = input(\"Enter project id\")\n",
+    "if not DATASET_ID: \n",
+    "    DATASET_ID = input(\"Enter dataset id\")\n",
+    "\n",
     "LOCATION = \"US\"\n",
+    "\n",
     "GCS_IMAGE_DATASET_PATH = \"gs://dataproc-metastore-public-binaries/home_image_search/house_images/*\"\n",
     "GCS_TEST_IMAGE_DATASET_PATH = \"gs://dataproc-metastore-public-binaries/home_image_search/test_image/*\""
    ]
@@ -146,8 +153,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#@title Create BigQuery dataset if not exists\n",
-    "\n",
     "query = f\"\"\"\n",
     "CREATE SCHEMA IF NOT EXISTS `{PROJECT_ID}.{DATASET_ID}`\n",
     "  OPTIONS (\n",
@@ -189,8 +194,6 @@
    },
    "outputs": [],
    "source": [
-    "#@title Create BQML model\n",
-    "\n",
     "query = f\"\"\"\n",
     "CREATE OR REPLACE MODEL `{PROJECT_ID}.{DATASET_ID}.home_search`\n",
     "REMOTE WITH CONNECTION DEFAULT\n",
@@ -232,8 +235,6 @@
    },
    "outputs": [],
    "source": [
-    "#@title Create external table\n",
-    "\n",
     "query = f\"\"\"\n",
     "CREATE OR REPLACE EXTERNAL TABLE `{PROJECT_ID}.{DATASET_ID}.external_images_table`\n",
     "WITH CONNECTION DEFAULT\n",
@@ -279,8 +280,6 @@
    },
    "outputs": [],
    "source": [
-    "#@title Generate embeddings for the images\n",
-    "\n",
     "query = f\"\"\"\n",
     "CREATE OR REPLACE TABLE `{PROJECT_ID}.{DATASET_ID}.home_embeddings` AS\n",
     "SELECT *\n",
@@ -352,7 +351,7 @@
    "source": [
     "## Create Vector Indexes\n",
     "\n",
-    "Use a vector index to enable faster and more scalable semantic search. A vector index efficiently finds the nearest neighbors of a query embedding within a large collection of embeddings using the CREATE VECTOR INDEX statement.\n",
+    "(Optional) Use a vector index to enable faster and more scalable semantic search. A vector index efficiently finds the nearest neighbors of a query embedding within a large collection of embeddings using the CREATE VECTOR INDEX statement.\n",
     "While vector indexes are ideal for large datasets, we are not creating an index in this case because we are only generating embeddings for 80 images.\n",
     "\n",
     "Learn more about Vector Indexes on BigQuery [here](https://cloud.google.com/bigquery/docs/vector-index#choose-vector-index-type).\n",
@@ -369,15 +368,26 @@
    },
    "outputs": [],
    "source": [
-    "\n",
+    "query = f\"\"\"\n",
+    "CREATE OR REPLACE\n",
+    "  VECTOR INDEX `house_images_index`\n",
+    "ON\n",
+    "  {DATASET_ID}.home_embeddings(ml_generate_embedding_result)\n",
+    "  OPTIONS (\n",
+    "    index_type = 'IVF',\n",
+    "    distance_type = 'COSINE');\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f99d5f5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# %%bigquery --project $PROJECT_ID\n",
-    "# CREATE OR REPLACE\n",
-    "#   VECTOR INDEX `house_images_index`\n",
-    "# ON\n",
-    "#   {DATASET_ID}.home_embeddings(ml_generate_embedding_result)\n",
-    "#   OPTIONS (\n",
-    "#     index_type = 'IVF',\n",
-    "#     distance_type = 'COSINE');"
+    "# $query"
    ]
   },
   {
@@ -392,6 +402,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1811bf63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = f\"\"\"\n",
+    "SELECT table_name, index_name, index_status,\n",
+    "  coverage_percentage, last_refresh_time, disable_reason\n",
+    "FROM {DATASET_ID}.INFORMATION_SCHEMA.VECTOR_INDEXES\n",
+    "WHERE index_name = 'house_images_index';\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "JUnmua-R05QT",
    "metadata": {
     "id": "JUnmua-R05QT"
@@ -399,10 +424,7 @@
    "outputs": [],
    "source": [
     "# %%bigquery --project $PROJECT_ID\n",
-    "# SELECT table_name, index_name, index_status,\n",
-    "#   coverage_percentage, last_refresh_time, disable_reason\n",
-    "# FROM {DATASET_ID}.INFORMATION_SCHEMA.VECTOR_INDEXES\n",
-    "# WHERE index_name = 'house_images_index';"
+    "# $query"
    ]
   },
   {
@@ -438,8 +460,6 @@
    },
    "outputs": [],
    "source": [
-    "#@title Create external table for the test image\n",
-    "\n",
     "query = f\"\"\"\n",
     "CREATE OR REPLACE EXTERNAL TABLE `{PROJECT_ID}.{DATASET_ID}.external_images_test_table`\n",
     "WITH CONNECTION DEFAULT\n",
@@ -524,8 +544,6 @@
    },
    "outputs": [],
    "source": [
-    "#@title Viewing the test image\n",
-    "\n",
     "from google.cloud import storage\n",
     "from io import BytesIO\n",
     "from PIL import Image\n",
@@ -580,8 +598,6 @@
    },
    "outputs": [],
    "source": [
-    "#@title Generate embeddings for the test image\n",
-    "\n",
     "query = f\"\"\"\n",
     "CREATE OR REPLACE TABLE `{PROJECT_ID}.{DATASET_ID}.test_embeddings` AS\n",
     "SELECT *\n",
@@ -628,8 +644,6 @@
    },
    "outputs": [],
    "source": [
-    "#@title Vector search\n",
-    "\n",
     "query = f\"\"\"\n",
     "CREATE OR REPLACE TABLE `{PROJECT_ID}.{DATASET_ID}.vector_search_results` AS\n",
     "SELECT base.uri AS gcs_uri, distance\n",
@@ -723,8 +737,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#@title Define print_images function\n",
-    "\n",
     "def print_images(query_result):\n",
     "    \"\"\"\n",
     "    Display images from BigQuery results containing GCS URIs and distances.\n",
@@ -828,8 +840,6 @@
    },
    "outputs": [],
    "source": [
-    "#@title Viewing the search result\n",
-    "\n",
     "from google.cloud import bigquery\n",
     "client = bigquery.Client()\n",
     "\n",
@@ -859,7 +869,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "myenv",
    "language": "python",
    "name": "python3"
   },
@@ -873,7 +883,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request updates the image_based_home_search.ipynb notebook by refining package installations, switching to the standard BigQuery extension, and adding interactive configuration for project and dataset IDs. It also introduces an optional section for vector indexing. Feedback focuses on using %pip for environment consistency, removing redundant dependencies, fixing trailing whitespace in input prompts, and ensuring SQL queries consistently use fully qualified table names (fix syntax).